### PR TITLE
[HOTFIX] Adding task url as secondary action on deadline notifications

### DIFF
--- a/modules/mail/deadline.js
+++ b/modules/mail/deadline.js
@@ -113,7 +113,7 @@ if (constants.canSendEmail) {
     },
     secondary: {
       label: 'mail.deadline.end.button.secondary',
-      url: urlInterested
+      url: task.url
     }
   })}
           <p>${Signatures.sign(language)}</p>`
@@ -127,7 +127,7 @@ if (constants.canSendEmail) {
     const language = user.language || 'en'
     const url = `${process.env.FRONTEND_HOST}/#/task/${task.id}`
     const urlInterested = `${process.env.FRONTEND_HOST}/#/task/${task.id}/interested`
-    const urlExtend = `${process.env.FRONTEND_HOST}/task/${task.id}/interested/extend`
+    // const urlExtend = `${process.env.FRONTEND_HOST}/task/${task.id}/interested/extend`
     i18n.setLocale(language)
     moment.locale(locales[language].label, locales[language].file)
     request(
@@ -147,7 +147,7 @@ if (constants.canSendEmail) {
     },
     secondary: {
       label: 'mail.deadline.end.owner.button.secondary',
-      url: urlExtend
+      url: task.url
     }
   })}
           <p>${Signatures.sign(language)}</p>`


### PR DESCRIPTION
## Description

> The second action about deadline notifications should be about the issue url, as we don't have a route to handle options like extend deadline yet

## Changes

- [ ] Deadline Notifications

## Status

> On review

## Related Issue

> #000

## Impacted Area

> Backend on email notifications

## Steps to test

- `git clone git@github.com:worknenjoy/gitpay.git`
- `cd gitpay/frontend`
- `npm install`
- `npm run dev`
- Go to http://localhost:8082
