### PR TITLE
Issue466

### DIFF
--- a/locales/br.json
+++ b/locales/br.json
@@ -16,6 +16,8 @@
   "mail.assign.owner.main": "{{name}} está interessado na sua tarefa <a href=\"{{url}}\">{{url}}</a>. Você pode entrar em contato com ele pelo e-mail {{email}} para saber mais.",
   "mail.assign.owner.suggest": "<p>Recompensa sugerida: ${{value}}</p><p>Data para entrega sugerida: {{suggestedDate}}</p><p>Quero esta tarefa como aprendizado: {{learn}}</p> <p>Comentários: {{comment}}</p>",
   "mail.assign.owner.sec": "Você pode atribuir esta tarefa na aba 'INTERESSADOS'. Assim ele receberá o valor quando que a tarefa for concluída.",
+  "mail.interested.user.assigned.main": "O usuário {{username}} foi escolhido para tarefa <strong>{{title}}</strong> - {{url}}, uma tarefa que você está interessado.</p><p>Não se preocupe, você pode escolher outra tarefas disponíveis.</p>",
+  "mail.interested.user.assigned.subject": "Um usuário foi escolhido para tarefa que você tem interesse",
   "mail.interested.owner.subject": "Você demonstrou interesse em realizar uma tarefa no Gitpay",
   "mail.interested.main": "Você demonstrou interesse em realizar a tarefa <a href=\"{{url}}\"</a> no Gitpay",
   "mail.interested.owner.sec": "O responsável pela tarefa será notificado e você receberá uma confirmação caso seja escolhido",

--- a/locales/en.json
+++ b/locales/en.json
@@ -30,6 +30,8 @@
   "mail.assign.owner.assigned.deadline.date": "You set the deadline for this task at: {{date}}",
   "mail.assign.owner.assigned.deadline.days": "So he have to send the solution in {{days}} days.",
   "mail.assign.owner.assigned.instructions": "The assigned user will follow these steps:<br/><br/>-The assigned user will create a fork of your project<br/>- The assigned user will follow the instructions to run locally<br/>- The assigned user will propose a solution<br/>- The assigned user will be synced with the main repo to watch any updates or changes<br/>- If you have a build pipeline, the code will go through your automated tests<br/>- The assigned user will send a Pull Request<br/>- You can review the code (If you use heroku, you can use review apps to test <a href=\"https://devcenter.heroku.com/articles/github-integration-review-apps\" title=\"Heroku Review apps\">Heroku review apps</a>)<br/>- When we have the Pull Request merged, he will receive the bounty you paid for this task",
+  "mail.interested.user.assigned.main": "<p>The user {{username}} was assigned to <strong>{{title}}</strong> - {{url}}, an issue that you were interested.</p><p>Don't worry, you can look for other issues available.</p>",
+  "mail.interested.user.assigned.subject": "User assigned for task you are interested",
   "mail.interested.owner.subject": "You're interested in this task",
   "mail.interested.main": "You're interested to work in the task <a href=\"{{url}}\"</a> on Gitpay",
   "mail.interested.owner.sec": "The owner is going to be notified about your interested and you will receive a confirmation if he accepts your request",

--- a/modules/mail/assign.js
+++ b/modules/mail/assign.js
@@ -146,10 +146,11 @@ if (constants.canSendEmail) {
     )
   }
 
-  AssignMail.notifyInterestedUser = (user, task) => {
+  AssignMail.notifyInterestedUser = (user, task, assignedUser) => {
     const to = user.email
     const language = user.language || 'en'
     const name = user.name || user.username
+    const assignedUserName = assignedUser.name || assignedUser.username
     i18n.setLocale(language)
     setMomentLocale(language)
     request(
@@ -160,7 +161,7 @@ if (constants.canSendEmail) {
           type: 'text/html',
           value: `
            <p>${i18n.__('mail.hello', { name: name })}</p>
-           <p>${i18n.__('mail.interested.user.assigned.main', { username: name, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
+           <p>${i18n.__('mail.interested.user.assigned.main', { username: assignedUserName, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
           ${Signatures.buttons(language, {
     primary: {
       label: 'mail.assigned.end.owner.button.primary',

--- a/modules/mail/assign.js
+++ b/modules/mail/assign.js
@@ -162,16 +162,7 @@ if (constants.canSendEmail) {
           value: `
            <p>${i18n.__('mail.hello', { name: name })}</p>
            <p>${i18n.__('mail.interested.user.assigned.main', { username: assignedUserName, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
-          ${Signatures.buttons(language, {
-    primary: {
-      label: 'mail.assigned.end.owner.button.primary',
-      url: `${process.env.FRONTEND_HOST}/#/task/${task.id}`
-    },
-    secondary: {
-      label: 'mail.assigned.end.owner.button.secondary',
-      url: `${task.url}`
-    }
-  })}
+          
            <p>${Signatures.sign(language)}</p>`
 
         }

--- a/modules/mail/assign.js
+++ b/modules/mail/assign.js
@@ -22,6 +22,7 @@ const AssignMail = {
     assigned: (to, task, name) => {},
   },
   messageInterested: (user, task, message) => {},
+  notifyInterestedUser: (user, task) => {},
   interested: (to, task, name) => {},
   assigned: (to, task) => {},
   error: (msg) => {}
@@ -128,6 +129,38 @@ if (constants.canSendEmail) {
     deadline: task.deadline ? dateFormat(task.deadline, constants.dateFormat) : i18n.__('mail.assigned.nodate'),
     deadlineFromNow: task.deadline ? moment(task.deadline).fromNow() : i18n.__('mail.assigned.anytime')
   })}
+          ${Signatures.buttons(language, {
+    primary: {
+      label: 'mail.assigned.end.owner.button.primary',
+      url: `${process.env.FRONTEND_HOST}/#/task/${task.id}`
+    },
+    secondary: {
+      label: 'mail.assigned.end.owner.button.secondary',
+      url: `${task.url}`
+    }
+  })}
+           <p>${Signatures.sign(language)}</p>`
+
+        }
+      ]
+    )
+  }
+
+  AssignMail.notifyInterestedUser = (user, task) => {
+    const to = user.email
+    const language = user.language || 'en'
+    const name = user.name || user.username
+    i18n.setLocale(language)
+    setMomentLocale(language)
+    request(
+      to,
+      i18n.__('mail.interested.user.assigned.subject'),
+      [
+        {
+          type: 'text/html',
+          value: `
+           <p>${i18n.__('mail.hello', { name: name })}</p>
+           <p>${i18n.__('mail.interested.user.assigned.main', { username: name, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
           ${Signatures.buttons(language, {
     primary: {
       label: 'mail.assigned.end.owner.button.primary',

--- a/modules/tasks/taskUpdate.js
+++ b/modules/tasks/taskUpdate.js
@@ -205,16 +205,16 @@ module.exports = Promise.method(function taskUpdate (taskParameters) {
                 const interestedUsersId = task.Assigns.map(user => user.userId).filter(user => user !== assignedUser.id)
                 AssignMail.owner.assigned(ownerUser, task.dataValues, assignedUser)
                 AssignMail.assigned(assignedUser, task.dataValues)
-                return interestedUsersId
+                return { interestedUsersId, assignedUser }
               })
-            }).then((interestedUsers) => {
+            }).then(({ interestedUsersId, assignedUser }) => {
               return models.User.findAll({
                 where: {
-                  id: interestedUsers
+                  id: interestedUsersId
                 }
               }).then(users => {
                 users.forEach(user => {
-                  AssignMail.notifyInterestedUser(user.dataValues, task.dataValues)
+                  AssignMail.notifyInterestedUser(user.dataValues, task.dataValues, assignedUser)
                 })
                 return task.dataValues
               })

--- a/modules/tasks/taskUpdate.js
+++ b/modules/tasks/taskUpdate.js
@@ -202,8 +202,20 @@ module.exports = Promise.method(function taskUpdate (taskParameters) {
               return task.updateAttributes({ status: 'in_progress' }).then(() => {
                 const assignedUser = assigned.User.dataValues
                 const ownerUser = task.dataValues.User.dataValues
+                const interestedUsersId = task.Assigns.map(user => user.userId).filter(user => user !== assignedUser.id)
                 AssignMail.owner.assigned(ownerUser, task.dataValues, assignedUser)
                 AssignMail.assigned(assignedUser, task.dataValues)
+                return interestedUsersId
+              })
+            }).then((interestedUsers) => {
+              return models.User.findAll({
+                where: {
+                  id: interestedUsers
+                }
+              }).then(users => {
+                users.forEach(user => {
+                  AssignMail.notifyInterestedUser(user.dataValues, task.dataValues)
+                })
                 return task.dataValues
               })
             })


### PR DESCRIPTION
## Description

When a user is assigned to an issue, all the interested users should receive an email so they know that someone was chosen to solve that issue.

## Changes

- Add locales for template in Portuguese and English, add function for module/mail/assign to send the template. Create callback when task is assigned to notify users that where not assigned but interested in the task.

## Issue

> #466 

## Impacted Area

> E-Mail notification

## Steps to test

 - Create an User
- Import an issue
- Create another two users
- One of these users show interest
- With the first user, you assign one
- The other interested should receive a notification

## Before
Not implemented.

## After
![2020-03-04-075828_1920x1080_scrot](https://user-images.githubusercontent.com/35773631/75897932-34f08900-5dee-11ea-846f-8abde1f53c74.png)
