### PR TITLE
Feat/sync issues status with GitHub webhooks

### DIFF
--- a/locales/br.json
+++ b/locales/br.json
@@ -39,6 +39,7 @@
   "mail.status.open": "Aberta",
   "mail.status.progress": "Em desenvolvimento",
   "mail.status.closed": "Finalizada",
+  "mail.status.when.closed": "<p>O issue {{title}} - {{url}} foi encerrado no Github, então encerramos no Gitpay.</p><p>Você pode alterar o status do issue, se desejar.</p>",
   "mail.notefined": "Status indefinido",
   "mail.status.error": "Tivemos um problema com as notificações sobre interessados em uma tarefa no Gitpay",
   "mail.transfer.new.subject.success": "Uma transferência foi realizada com sucesso",

--- a/locales/en.json
+++ b/locales/en.json
@@ -70,6 +70,7 @@
   "mail.status.open": "Open",
   "mail.status.progress": "In progress",
   "mail.status.closed": "Done",
+  "mail.status.when.closed": "<p>The issue {{title}} - {{url}} was closed on Github, so we closed on Gitpay.</p><p>You can change the issue status if you want.</p>",
   "mail.notefined": "Undefined",
   "mail.status.error": "We had a issue with some notifications about interested users for a task on Gitpay",
   "mail.transfer.new.subject.success": "A new transfer was made for a task on Gitpay",

--- a/locales/result/br.json
+++ b/locales/result/br.json
@@ -70,6 +70,7 @@
   "mail.status.open": "Aberta",
   "mail.status.progress": "Em desenvolvimento",
   "mail.status.closed": "Finalizada",
+  "mail.status.when.closed": "<p>O issue {{title}} - {{url}} foi encerrado no Github, então encerramos no Gitpay.</p><p>Você pode alterar o status do issue, se desejar.</p>",
   "mail.notefined": "Status indefinido",
   "mail.status.error": "Tivemos um problema com as notificações sobre interessados em uma tarefa no Gitpay",
   "mail.transfer.new.subject.success": "Uma transferência foi realizada com sucesso",

--- a/locales/result/en.json
+++ b/locales/result/en.json
@@ -70,6 +70,7 @@
   "mail.status.open": "Open",
   "mail.status.progress": "In progress",
   "mail.status.closed": "Done",
+  "mail.status.when.closed": "<p>The issue {{title}} - {{url}} was closed on Github, so we closed on Gitpay.</p><p>You can change the issue status if you want.</p>",
   "mail.notefined": "Undefined",
   "mail.status.error": "We had an issue with some notifications about interested users for a task on Gitpay",
   "mail.transfer.new.subject.success": "A new transfer was made for an issue added to Gitpay.",

--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -49,14 +49,9 @@ exports.github = async (req, res) => {
         },
         returning: true
       })
-      const TaskAfter = await models.Task.findOne({
-        where: {
-          url: dbUrl
-        }
-      })
       if (updated) {
         return res.json({ ...response,
-          task: TaskAfter.dataValues })
+          task: updated[1][0].dataValues })
       }
       else return res.status(500).json({})
     }

--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -46,7 +46,8 @@ exports.github = async (req, res) => {
       const updated = await models.Task.update({ status: status }, {
         where: {
           url: dbUrl
-        }
+        },
+        returning: true
       })
       const TaskAfter = await models.Task.findOne({
         where: {

--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -40,7 +40,7 @@ exports.github = async (req, res) => {
   const labels = response && response.issue && response.issue.labels
   if (req.headers.authorization === `Bearer ${process.env.GITHUB_WEBHOOK_APP_TOKEN}`) {
     // below would update issue status if someone updates it on Github
-    if (response.action === 'reopened' || 'opened' || 'closed') {
+    if (response.action === 'reopened' || response.action === 'opened' || response.action === 'closed') {
       const status = response.issue.state
       const dbUrl = response.issue.html_url
       models.Task.update({ status: status }, {

--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -39,6 +39,17 @@ exports.github = async (req, res) => {
   const response = req.body || res.body
   const labels = response && response.issue && response.issue.labels
   if (req.headers.authorization === `Bearer ${process.env.GITHUB_WEBHOOK_APP_TOKEN}`) {
+    // below would update issue status if someone updates it on Github
+    if (response.action === 'reopened' || 'opened' || 'closed') {
+      const status = response.issue.state
+      const dbUrl = response.issue.html_url
+      models.Task.update({ status: status }, {
+        where: {
+          url: dbUrl
+        }
+      })
+      return res.status(200).end()
+    }
     if (response.action === 'labeled') {
       const labelNotify = labels.filter(label => label.name === 'notify')
       const labelGitpay = labels.filter(label => label.name === 'gitpay')

--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -43,12 +43,21 @@ exports.github = async (req, res) => {
     if (response.action === 'reopened' || response.action === 'opened' || response.action === 'closed') {
       const status = response.issue.state
       const dbUrl = response.issue.html_url
-      models.Task.update({ status: status }, {
+      const updated = await models.Task.update({ status: status }, {
         where: {
           url: dbUrl
         }
       })
-      return res.status(200).end()
+      const TaskAfter = await models.Task.findOne({
+        where: {
+          url: dbUrl
+        }
+      })
+      if (updated) {
+        return res.json({ ...response,
+          task: TaskAfter.dataValues })
+      }
+      else return res.status(500).json({})
     }
     if (response.action === 'labeled') {
       const labelNotify = labels.filter(label => label.name === 'notify')

--- a/modules/mail/issueClosed.js
+++ b/modules/mail/issueClosed.js
@@ -1,0 +1,49 @@
+const Signatures = require('./content')
+const request = require('./request')
+const constants = require('./constants')
+const moment = require('moment')
+const ptLocale = require('moment/locale/pt-br')
+const i18n = require('i18n')
+
+moment.locale('pt-br', ptLocale)
+
+const IssueClosedMail = {
+  success: (to, data) => {},
+  error: (msg) => {}
+}
+
+if (constants.canSendEmail) {
+  IssueClosedMail.success = (user, data) => {
+    const to = user.email
+    const language = user.language || 'en'
+    i18n.setLocale(language)
+    request(
+      to,
+      i18n.__('mail.status.subject'),
+      [
+        {
+          type: 'text/html',
+          value: `
+          <p>${i18n.__('mail.hello', { name: data.name })}</p>
+          ${i18n.__('mail.status.when.closed', { url: data.url, title: data.title })}
+          <p>${Signatures.sign(language)}</p>`
+        },
+      ]
+    )
+  }
+
+  IssueClosedMail.error = (msg) => {
+    request(
+      constants.notificationEmail,
+      i18n.__('mail.status.error'),
+      [
+        {
+          type: 'text/html',
+          value: msg
+        },
+      ]
+    )
+  }
+}
+
+module.exports = IssueClosedMail

--- a/server.js
+++ b/server.js
@@ -63,8 +63,6 @@ app.post('/webhooks/github', (req, res, next) => {
   if (updateStatus) {
     const status = req.body.issue.state
     const dbUrl = req.body.issue.html_url
-    // eslint-disable-next-line no-console
-    console.log(status)
     models.Task.update({ status: status }, {
       where: {
         url: dbUrl

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const app = express()
 const session = require('express-session')
 const bodyParser = require('body-parser')
 require('./models')
-const models = require('./models')
 const passport = require('passport')
 require('./config/passport')
 const load = require('./modules/app')
@@ -55,21 +54,6 @@ app.get('/octos', (req, res) => {
     console.log(article)
     return res.json(article).end()
   })
-})
-
-// Correct webhook route should be configured according to your GitHub App
-app.post('/webhooks/github', (req, res, next) => {
-  const updateStatus = (req.body.action === 'reopened' || 'opened' || 'closed')
-  if (updateStatus) {
-    const status = req.body.issue.state
-    const dbUrl = req.body.issue.html_url
-    models.Task.update({ status: status }, {
-      where: {
-        url: dbUrl
-      }
-    })
-  }
-  res.status(200).end()
 })
 
 load.init(app)

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const app = express()
 const session = require('express-session')
 const bodyParser = require('body-parser')
 require('./models')
+const models = require('./models')
 const passport = require('passport')
 require('./config/passport')
 const load = require('./modules/app')
@@ -54,6 +55,23 @@ app.get('/octos', (req, res) => {
     console.log(article)
     return res.json(article).end()
   })
+})
+
+// Correct webhook route should be configured according to your GitHub App
+app.post('/webhook', (req, res, next) => {
+  const updateStatus = (req.body.action === 'reopened' || 'opened' || 'closed')
+  if (updateStatus) {
+    const status = req.body.issue.state
+    const dbUrl = req.body.issue.html_url
+    // eslint-disable-next-line no-console
+    console.log(status)
+    models.Task.update({ status: status }, {
+      where: {
+        url: dbUrl
+      }
+    })
+  }
+  res.status(200).end()
 })
 
 load.init(app)

--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.get('/octos', (req, res) => {
 })
 
 // Correct webhook route should be configured according to your GitHub App
-app.post('/webhook', (req, res, next) => {
+app.post('/webhooks/github', (req, res, next) => {
   const updateStatus = (req.body.action === 'reopened' || 'opened' || 'closed')
   if (updateStatus) {
     const status = req.body.issue.state

--- a/test/webhook.test.js
+++ b/test/webhook.test.js
@@ -396,6 +396,19 @@ describe('webhooks', () => {
           done()
         });      
     })
+    it('should update issue status when an issue updates on github', done => {
+      agent
+        .post('/webhooks/github')
+        .send(githubWebhookMain.issue)
+        .expect('Content-Type', /json/)
+        .end((err, res) => {
+          models.Task.findOne({where: {url: "https://github.com/worknenjoy/gitpay/issues/244"}})
+          .then((task)=>{
+            expect(task.dataValues.status).to.equal("open")
+          })
+          done()
+        });      
+    })
     xit('should create new task when an event of new issue is triggered', done => {
       agent
         .post('/webhooks/github')


### PR DESCRIPTION
## Description

> This allows to sync the issue status on Github with our website.

## Changes

- /modules/app/controllers/webhooks.js
- /test/webhook.test.js

## Issue

> #484 

## Impacted Area

> I've added update query so database gets updated.
>All the pages where issue status is displayed

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- I have added the test in `/test/webhook.test.js`
- Similar to the test you can create your own and test if the thing works.

*Some other steps you can follow(requires postman)*
- Start the backend server.
- (Optional)Start pgAdmin to see change in database.
- Send post requests through postman with the data as json.

## Before
> Screenshot from the state before

## After
> Screenshot from the state after your Pull Request
