### PR TITLE
Fix FRONTEND_HOST env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-FRONTEND_HOST="http://localhost:8082"
+FRONTEND_HOST=http://localhost:8082
 API_HOST="http://localhost:3000"
 PAYPAL_HOST="https://api.sandbox.paypal.com"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "file-loader": "^3.0.1",
     "history": "^4.7.2",
     "human-format": "^0.10.1",
+    "invert-color": "^2.0.0",
     "is-github-url": "^1.2.2",
     "jss": "^9.8.7",
     "lodash": "^4.17.11",


### PR DESCRIPTION
## Description

This PR removes quotes from the environment variable that specifies the frontend app host.
For some reason NodeJS doesn't remove them on Linux (it does on Mac OS).
I have no experience en NodeJS, so I didn't dig further, maybe a follow-up request could fix this differently, but at least this will unblock docker environment.

It also adds the `invert-color` dependency to the frontend packages as stated in the [issue comment](https://github.com/worknenjoy/gitpay/issues/460#issuecomment-591065211)

## Changes

-  .`env.example`
- `frontend/package.json`

## Issue

> #460 

## Impacted Area

> Login

## Steps to test

Clone this branch and follow these steps:

- `cp .env.example .env`
- `docker-compose up`
- Run `docker container exec gitpay_backend_1 npm run migrate`
- Run `docker container exec gitpay_backend_1 npm run seed` 
- Browse `http://localhost:8082`
- Click SIGNIN/SIGNUP button
- Login with `user1@example.com:123456`

## Before
![image](https://user-images.githubusercontent.com/43977/77220536-f4984700-6b1f-11ea-9437-81831e3828b8.png)


## After
![image](https://user-images.githubusercontent.com/43977/77220576-4e990c80-6b20-11ea-8d4f-b09cc8676716.png)
