### PR TITLE
Issue#566

### DIFF
--- a/frontend/build/messages/src/components/profile/preferences.json
+++ b/frontend/build/messages/src/components/profile/preferences.json
@@ -30,13 +30,5 @@
   {
     "id": "preferences.notifications.checkbox",
     "defaultMessage": "I want to receive notifications about all the tasks, not just the ones I'm interested"
-  },
-  {
-    "id": "general.actions.cancel",
-    "defaultMessage": "Cancel"
-  },
-  {
-    "id": "preferences.action.save",
-    "defaultMessage": "Save"
   }
 ]

--- a/frontend/src/components/profile/preferences.js
+++ b/frontend/src/components/profile/preferences.js
@@ -38,9 +38,24 @@ class Preferences extends Component {
 
     this.state = {
       selectedSkills: this.props.preferences.skills != null && this.props.preferences.skills.length > 0 ? this.props.preferences.skills.split(',') : [],
-      selectedOS: this.props.preferences.os != null && this.props.preferences.skills.length > 0 ? this.props.preferences.os.split(',') : [],
+      selectedOS: this.props.preferences.os ? this.props.preferences.os.split(',') : [],
       selectedLanguage: this.props.preferences.language ? this.props.preferences.language : null,
       receiveNotifications: this.props.preferences.receiveNotifications != null ? this.props.preferences.receiveNotifications : false,
+    }
+  }
+
+  componentDidUpdate = (prevProps, prevState) => {
+    if (
+      prevProps.preferences.skills !== prevState.selectedSkills.toString() ||
+      prevProps.preferences.os !== prevState.selectedOS.toString() ||
+      prevProps.preferences.receiveNotifications !== this.state.receiveNotifications
+    ) {
+      this.handleSave()
+    }
+    else if (
+      prevState.selectedLanguage !== this.state.selectedLanguage
+    ) {
+      this.handleSave(true)
     }
   }
 

--- a/frontend/src/components/profile/preferences.js
+++ b/frontend/src/components/profile/preferences.js
@@ -119,7 +119,7 @@ class Preferences extends Component {
     })
   }
 
-  handleSave = () => {
+  handleSave = (fetchPreferences = false) => {
     // prevent blink
     this.props.preferences.skills = this.state.selectedSkills.join(',')
     this.props.preferences.os = this.state.selectedOS.join(',')
@@ -131,7 +131,7 @@ class Preferences extends Component {
       language: this.state.selectedLanguage,
       receiveNotifications: this.state.receiveNotifications
     }).then(() => {
-      this.props.fetchPreferences(this.props.user.id)
+      fetchPreferences && this.props.fetchPreferences(this.props.user.id)
     })
   }
 

--- a/frontend/src/components/profile/preferences.js
+++ b/frontend/src/components/profile/preferences.js
@@ -282,20 +282,6 @@ class Preferences extends Component {
               </Typography>
             </label>
           </Grid>
-          <Grid item xs={ 12 } alignContent='center' alignItems='center' style={ { 'textAlign': 'center' } }>
-            <Button color='primary' onClick={ () => this.handleCancel() }>
-              <FormattedMessage id='general.actions.cancel' defaultMessage='Cancel' />
-            </Button>&nbsp;
-            <Button
-              style={ { color: 'white' } }
-              size='large'
-              variant='contained'
-              color='primary'
-              onClick={ () => this.handleSave() }
-            >
-              <FormattedMessage id='preferences.action.save' defaultMessage='Save' />
-            </Button>
-          </Grid>
         </Grid>
       </Paper>
     )


### PR DESCRIPTION
## Description

User had to save preferences by clicking on saving button in order to make a request for update preference information as skills, OS, language and notification. This PR will save user preference when user change data.

## Changes

User preference is automatically saved if different from the user props data, removed saved button. The data will only be fetched if language is changed in order to update front-end translation.

## Issue

> #566 

## Impacted Area

> User Preference Page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Access User Preference
- Modify preference

## Before
![before](https://user-images.githubusercontent.com/35773631/78171422-11584700-745d-11ea-8a7e-f8c1245bf519.png)

## After
![after](https://user-images.githubusercontent.com/35773631/78171432-14533780-745d-11ea-9d67-a9e8b2cfad20.png)
