### PR TITLE
Fixed issue(#529)

### DIFF
--- a/frontend/src/components/task/task-table.js
+++ b/frontend/src/components/task/task-table.js
@@ -247,7 +247,7 @@ class CustomPaginationActionsTable extends React.Component {
                           <a style={ { cursor: 'pointer' } } onClick={ () => this.handleClickListItem(n.id) }>
                             { TextEllipsis(`${n.title || 'sem título'}`, 30) }
                           </a>
-                          <a target='_blank' href={ n.url }>
+                          <a target='_blank' href={ n.url } rel='nooprner noreferrer'>
                             <Tooltip id='tooltip-fab' title={ `Ver no ${n.provider}` } placement='top'>
                               <img width='24' src={ n.provider === 'github' ? logoGithub : logoBitbucket } style={ { borderRadius: '50%', padding: 3, backgroundColor: 'black', borderColor: 'black', borderWidth: 1, marginLeft: 10 } } />
                             </Tooltip>


### PR DESCRIPTION


## Description
 when a user clicks on the provider link(Github or BitBucket) should go to a new tab.


## Changes
A new tab is opened when a user clicks on a provider link.

- Where your changes apply


## Issue
#529 



## Impacted Area
A  user can navigate to a different tab to see an issue.

> Main page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Create Task
- Click on provider link(Github or BitBucket)



## Before
>![ice_screenshot_20200404-191830](https://user-images.githubusercontent.com/11736897/78458438-393bea80-76a9-11ea-9d3b-227d1b75a06c.png)


## After
> ![ice_screenshot_20200404-192052](https://user-images.githubusercontent.com/11736897/78458460-730cf100-76a9-11ea-9bc2-addffd98e34e.png)
