### PR TITLE
[GitHub API] Deprecation notice for authentication via URL query parameters

### DIFF
--- a/modules/app/controllers/auth.js
+++ b/modules/app/controllers/auth.js
@@ -36,13 +36,17 @@ exports.createPrivateTask = (req, res) => {
   const githubClientId = secrets.github.id
   const githubClientSecret = secrets.github.secret
   return requestPromise({
-    uri: `https://github.com/login/oauth/access_token/?client_id=${githubClientId}&client_secret=${githubClientSecret}&code=${code}`,
+    method: 'POST',
+    uri: 'https://github.com/login/oauth/access_token/',
     headers: {
-      'User-Agent': 'octonode/0.3 (https://github.com/pksunkara/octonode) terminal/0.0'
+      'User-Agent': 'octonode/0.3 (https://github.com/pksunkara/octonode) terminal/0.0',
+      Authorization: 'Basic ' + Buffer.from(`${githubClientId}:${githubClientSecret}`).toString('base64')
+    },
+    body: {
+      code
     },
     json: true
   }).then(response => {
-    if (response.error) return res.status(401).send(response.error)
     if (response.access_token) {
       return task.taskBuilds({
         provider: 'github',
@@ -61,7 +65,7 @@ exports.createPrivateTask = (req, res) => {
           return res.send(error)
         })
     }
-    return res.status(200).send(response)
+    return res.status(response.access_token ? 200 : 401).send(response)
   }).catch(e => {
     return res.status(401).send(e)
   })


### PR DESCRIPTION
## Description

- GitHub will replace and discontinue OAuth endpoints containing access_token in the path parameter. We are introducing new endpoints that allow you to securely manage tokens for OAuth Apps by using access_token as an input parameter. The OAuth Application API will be removed on July 1, 2020

- Gitpay used its client_id and client_secret  as part of a set of query parameters to access an endpoint through the GitHub API

- Use Basic Authentication instead as using OAuth credentials in query parameters has been deprecated and will be removed July 1st, 2020

## Changes

- Use Basic Authentication instead as using OAuth credentials in query parameters.

## Issue

Closes #452 

[[GITPAY] Deprecation notice for authentication via URL query parameters](https://gitpay.me/#/task/315)

## Impacted Area

- Backend Controller Auth

## Steps to test

- Create / log user
- Create a Private Task