### PR TITLE
#541 add another avatar on task page

### DIFF
--- a/frontend/src/components/task/task.js
+++ b/frontend/src/components/task/task.js
@@ -868,20 +868,20 @@ class Task extends Component {
               } }
             >
               { task.data.metadata ? (
-                <div style={ { position: 'absolute', left: 18, top: 5 } }>
+                <div style={ { position: 'absolute', left: 40, top: 5 } }>
                   <Typography color='default'>
                     <FormattedMessage id='task.status.author.label' defaultMessage='Author' />
                   </Typography>
                 </div>
               ) : (
-                <div style={ { position: 'absolute', left: 18, top: 5 } }>
+                <div style={ { position: 'absolute', left: 40, top: 5 } }>
                   <Typography color='default'>
                     <FormattedMessage id='task.status.author.missing' defaultMessage='author info unknown' />
                   </Typography>
                 </div>
               ) }
               { task.data.metadata &&
-              <FormattedMessage id='task.status.created.name' defaultMessage='Created by {name}' values={ {
+              <FormattedMessage id='task.status.author.name' defaultMessage='Author from provider {name}' values={ {
                 name: task.data.metadata.issue.user.login
               } }>
                 { (msg) => (
@@ -893,9 +893,34 @@ class Task extends Component {
                     <a
                       href={ `${task.data.metadata.issue.user.html_url}` }
                       target='_blank'
+
                     >
                       <Avatar
                         src={ task.data.metadata.issue.user.avatar_url }
+                        className={ classNames(classes.avatar) }
+                      />
+                    </a>
+                  </Tooltip>
+                ) }
+              </FormattedMessage>
+              }
+              { task.data.metadata &&
+              <FormattedMessage id='task.status.importer.name' defaultMessage='Imported to Gitpay by {name}' values={ {
+                name: this.props.user.name
+              } }>
+                { (msg) => (
+                  <Tooltip
+                    id='tooltip-github'
+                    title={ msg }
+                    placement='bottom'
+                  >
+                    <a
+                      href={ `${this.props.user.html_url}` }
+                      target='_blank'
+                      style={ { marginLeft: 5 } }
+                    >
+                      <Avatar
+                        src={ this.props.user.avatar_url }
                         className={ classNames(classes.avatar) }
                       />
                     </a>


### PR DESCRIPTION
## Description

We need to display who is the original author (from Github or Bitbucket) and who created on Gitpay
## Changes

gitpay/frontend/src/components/task/task.js

## Issue
![requirement_tagging](https://user-images.githubusercontent.com/63766141/79706899-6529b380-82d8-11ea-8010-baa202f209ec.png)

> Closes #000

## Impacted Area

Task page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Create Task
- Other steps

## Before
> Screenshot from the state before

## After
> Screenshot from the state after your Pull Request
![hover_author_provider](https://user-images.githubusercontent.com/63766141/79706953-8a1e2680-82d8-11ea-8ca8-da96df2cf6b1.png)
![hover_createdby_gitpay](https://user-images.githubusercontent.com/63766141/79706958-8db1ad80-82d8-11ea-8ed9-1604a045172b.png)
