### PR TITLE
add currency support for payout created webhook

### DIFF
--- a/modules/app/controllers/webhook.js
+++ b/modules/app/controllers/webhook.js
@@ -21,10 +21,27 @@ const FAILED_REASON = {
 }
 
 const CURRENCIES = {
-  brl: 'R$',
-  usd: '$',
+  aud: '$',
   eur: '€',
-  dkk: 'DK'
+  brl: 'R$',
+  cad: 'C$',
+  czk: 'Kč',
+  dkk: 'DK',
+  hkd: 'HK$',
+  inr: '₹',
+  jpy: '¥',
+  myr: 'RM',
+  mxn: 'Mex$',
+  nzd: 'NZ$',
+  nok: 'kr',
+  isk: 'kr',
+  pln: 'zł',
+  ron: 'lei',
+  sgd: 'S$',
+  sek: 'kr',
+  chf: 'fr',
+  gbp: '£',
+  usd: '$'
 }
 
 i18n.configure({

--- a/package-lock.json
+++ b/package-lock.json
@@ -866,19 +866,21 @@
       "resolved": "https://registry.npmjs.org/bitbucket-api-v2/-/bitbucket-api-v2-0.6.2.tgz",
       "integrity": "sha512-T5rU63+qhA6dxzsfdxuLuEuSjr3JDOyufl0o8efAUJQedyRq89c4CdosqGjmIJ7MJPMDaGeX5j1jK/7vc+pGiA==",
       "requires": {
-        "bitbucket-auth": "github:kristianmandrup/bitbucket-auth",
+        "bitbucket-auth": "bitbucket-auth@github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
         "lodash": "^4.17.4",
         "oauth": "^0.9.15",
         "superagent": "^3.7.0",
         "underscore.string": "^3.3.4",
         "xhr": "^2.4.0"
-      }
-    },
-    "bitbucket-auth": {
-      "version": "github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
-      "from": "github:kristianmandrup/bitbucket-auth",
-      "requires": {
-        "supertest": "^3.0.0"
+      },
+      "dependencies": {
+        "bitbucket-auth": {
+          "version": "github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
+          "from": "bitbucket-auth@github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
+          "requires": {
+            "supertest": "^3.0.0"
+          }
+        }
       }
     },
     "bitbucket-v2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -866,21 +866,19 @@
       "resolved": "https://registry.npmjs.org/bitbucket-api-v2/-/bitbucket-api-v2-0.6.2.tgz",
       "integrity": "sha512-T5rU63+qhA6dxzsfdxuLuEuSjr3JDOyufl0o8efAUJQedyRq89c4CdosqGjmIJ7MJPMDaGeX5j1jK/7vc+pGiA==",
       "requires": {
-        "bitbucket-auth": "bitbucket-auth@github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
+        "bitbucket-auth": "github:kristianmandrup/bitbucket-auth",
         "lodash": "^4.17.4",
         "oauth": "^0.9.15",
         "superagent": "^3.7.0",
         "underscore.string": "^3.3.4",
         "xhr": "^2.4.0"
-      },
-      "dependencies": {
-        "bitbucket-auth": {
-          "version": "github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
-          "from": "bitbucket-auth@github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
-          "requires": {
-            "supertest": "^3.0.0"
-          }
-        }
+      }
+    },
+    "bitbucket-auth": {
+      "version": "github:kristianmandrup/bitbucket-auth#cbabe9b4a95b1e1a5aa9d124e67b1b9ac84f3b4b",
+      "from": "github:kristianmandrup/bitbucket-auth",
+      "requires": {
+        "supertest": "^3.0.0"
       }
     },
     "bitbucket-v2": {


### PR DESCRIPTION
## Description

> add support for all currencies when a payout intransit email is sent using the payout.created webhook

## Changes

- in ``/modules/app/controllers/webhooks.js``

## Issue

> Closes #548

## Impacted Area

> In email template in files ``/locales/en.json``

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue
- no test in local env
