### PR TITLE
resolved issue #504

### DIFF
--- a/frontend/src/components/task/task.js
+++ b/frontend/src/components/task/task.js
@@ -569,12 +569,12 @@ class Task extends Component {
 
   handlePaymentForm = (e) => {
     e.preventDefault()
-    this.state.paymentForm ? this.setState({ paymentForm: false }) : this.setState({ paymentForm: true })
+    this.state.paymentForm ? this.setState({ paymentForm: false }) : this.setState({ paymentForm: true, deadlineForm: false })
   }
 
   handleDeadlineForm = (e) => {
     e.preventDefault()
-    this.state.deadlineForm ? this.setState({ deadlineForm: false }) : this.setState({ deadlineForm: true })
+    this.state.deadlineForm ? this.setState({ deadlineForm: false }) : this.setState({ deadlineForm: true, paymentForm: false })
   }
 
   handleInvite = () => {


### PR DESCRIPTION
now only one tab will open either add bounty or deadline.

## Description

now only one tab will remain open either the add bounty or the deadline tab

## Changes

changes were made in task.js to resolve the issue

## Issue

> Closes #504 

## Impacted Area

> task page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create user
- import a issue
- Click on bounty tab and then deadline tab (now only one will remain open)

## Before
> Screenshot from the state before

## After
> Screenshot from the state after your Pull Request
