### PR TITLE
Issue #562

### DIFF
--- a/models/order.js
+++ b/models/order.js
@@ -1,3 +1,5 @@
+const comment = require('../modules/bot/comment')
+
 module.exports = (sequelize, DataTypes) => {
   const Order = sequelize.define('Order', {
     source_id: DataTypes.STRING,
@@ -36,6 +38,14 @@ module.exports = (sequelize, DataTypes) => {
     },
     instanceMethods: {
 
+    },
+    hooks: {
+      afterUpdate: async (instance, options) => {
+        if (instance.paid) {
+          const task = await sequelize.models.Task.findById(instance.TaskId)
+          await comment(instance, task)
+        }
+      }
     }
   })
 

--- a/modules/bot/comment.js
+++ b/modules/bot/comment.js
@@ -3,7 +3,7 @@ const Promise = require('bluebird')
 
 module.exports = Promise.method(async function comment (offer, task) {
   const { provider, url, id } = task.dataValues
-  if (provider !== 'github') return
+  if (provider !== 'github' || process.env.NODE_ENV !== 'production') return
   const { currency, amount } = offer
   const [, , , owner, repo, , issueNumber] = url.split('/')
 

--- a/modules/bot/comment.js
+++ b/modules/bot/comment.js
@@ -23,7 +23,7 @@ module.exports = Promise.method(async function comment (offer, task) {
     },
     json: true,
     body: {
-      body: `A bounty of *${amount} ${currency}* was added on this issue. See task on [GitPay](${gitPayURL})`
+      body: `A bounty of *${amount} ${currency}* was added to this issue. See task on [GitPay](${gitPayURL})`
     }
   })
 

--- a/modules/bot/comment.js
+++ b/modules/bot/comment.js
@@ -1,0 +1,31 @@
+const requestPromise = require('request-promise')
+const Promise = require('bluebird')
+
+module.exports = Promise.method(async function comment (offer, task) {
+  const { provider, url, id } = task.dataValues
+  if (provider !== 'github') return
+  const { currency, amount } = offer
+  const [, , , owner, repo, , issueNumber] = url.split('/')
+
+  const githubApiEndpoint = 'https://api.github.com'
+
+  const commentIssueEndpoint = `${githubApiEndpoint}/repos/${owner}/${repo}/issues/${issueNumber}/comments`
+
+  const gitPayURL = `${process.env.FRONTEND_HOST}/#/task/${id}`
+
+  const req = await requestPromise({
+    method: 'POST',
+    uri: `${commentIssueEndpoint}`,
+    headers: {
+      'User-Agent': 'Gitpay',
+      'Content-Type': 'application/json',
+      'Authorization': 'token ' + process.env.GITHUB_BOT_ACCESS_TOKEN
+    },
+    json: true,
+    body: {
+      body: `A bounty of *${amount} ${currency}* was added on this issue. See task on [GitPay](${gitPayURL})`
+    }
+  })
+
+  return req
+})


### PR DESCRIPTION
## Description

> When an issue from Github imported to Gitpay and a bounty is added, add a comment on this issue:
A bounty of 10USD was added to this issue. See task on Gitpay: {{url}}

Unfortunately the bot would be not able to add Label to the issue since only the owner or member can do it.

## Changes

- Added Hook on Offer to trigger when paid and commenting on issue.
- Need to add GITHUB_BOT_ACCESS_TOKEN= to .env
- Generate Token for [https://github.com/gitpaybot](https://github.com/gitpaybot)
[Create Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
## Issue

> closes #562 

## Impacted Area

> Front-End Task
> Back-End: Offer Model

## Steps to test

- Create / log user
- Create Task
- Add a bounty and pay
- A comment will be added into github issue

## After
![Untitled](https://user-images.githubusercontent.com/35773631/82280008-8e506900-9996-11ea-8bc9-7ae123f71252.png)
