### PR TITLE
fix(assign):remmoval of email information of assigned user

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -17,7 +17,7 @@
   "mail.payment.support": "User request support for Task",
   "mail.assign.owner.subject": "Someone is interested in a task that you created on Gitpay",
   "mail.assign.owner.hello": "Hello",
-  "mail.assign.owner.main": "{{name}} is interested to work on the task <a href=\"{{url}}\">{{title}}</a>. You can contact him on {{email}} to know more.",
+  "mail.assign.owner.main": "{{name}} is interested to work on the task <a href=\"{{url}}\">{{title}}</a>.",
   "mail.assign.owner.suggest": "<p>Suggested bounty: <strong>${{value}}</strong></p> <p>Suggested date: <strong>{{suggestedDate}}</strong></p> <p>For learning purposes: <strong>{{learn}}</strong></p><p>Comment: {{comment}}</p>",
   "mail.assign.owner.sec": "You can accept this proposal or reject.",
   "mail.assign.owner.button.primary": "Accept work and assign him to this task",

--- a/modules/mail/assign.js
+++ b/modules/mail/assign.js
@@ -80,7 +80,6 @@ ${Signatures.buttons(language, {
           value: `
           <p>${i18n.__('mail.hello', { name })}</p>
           <p>${i18n.__('mail.assign.owner.assigned.main', { assignedName, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
-          <p>${i18n.__('mail.assign.owner.assigned.contact', { assignedEmail: interested.email })}</p>
           <p>${i18n.__('mail.assign.owner.assigned.deadline.date', { date: deadline })}</p>
           <p>${i18n.__('mail.assign.owner.assigned.deadline.days', { days: deadlineFromNow })}</p>
           <p>${i18n.__('mail.assign.owner.assigned.instructions')}</p>
@@ -161,7 +160,7 @@ ${Signatures.buttons(language, {
           value: `
            <p>${i18n.__('mail.hello', { name: name })}</p>
            <p>${i18n.__('mail.interested.user.assigned.main', { username: assignedUserName, title: task.title, url: `${process.env.FRONTEND_HOST}/#/task/${task.id}` })}</p>
-          
+
            <p>${Signatures.sign(language)}</p>`
 
         }


### PR DESCRIPTION
### Description

This PR removes Email information for assigned user from following emails contents and both locale
Having subjects
1.Someone is interested in a task that you created on Gitpay
2. You have assigned {{name}} to do a task
### Changes

> modules/mail/assign.js
> locales/en.json

### Issue

 >Closes #530

### Impacted Area

   > AssignMail.owner.interested
   > AssignMail.owner.assigned

### Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

-create an user
-Import an issue
-Create another user
-Apply to solve an issue in I'm interested (An email should be sent with subject 'Someone is interested in a task that you created on Gitpay')
-Log with the first user
-Assign user
-Accept from Second user (An email should be sent with subject 'You have assigned {{name}} to do a task')

### Before
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/8337585/88295292-da16ea00-cd1a-11ea-9492-31d48f4173ad.png">

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/8337585/88295525-295d1a80-cd1b-11ea-9ccd-7217d0fd6edc.png">


### After
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/8337585/88295361-f1ee6e00-cd1a-11ea-8726-7bd97c7cd896.png">

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/8337585/88295568-3843cd00-cd1b-11ea-9705-7ca3eb0962c6.png">

