### PR TITLE
Fixed button style on click (clip style)

### DIFF
--- a/frontend/src/components/task/task-status-filter.js
+++ b/frontend/src/components/task/task-status-filter.js
@@ -13,9 +13,9 @@ const styles = theme => ({
   selected: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
-    '&:hover' : {
-        color: theme.palette.primary.contrastText,
-        backgroundColor: theme.palette.primary.main,
+    '&:hover': {
+      color: theme.palette.primary.contrastText,
+      backgroundColor: theme.palette.primary.main,
     }
   }
 })

--- a/frontend/src/components/task/task-status-filter.js
+++ b/frontend/src/components/task/task-status-filter.js
@@ -12,7 +12,11 @@ import {
 const styles = theme => ({
   selected: {
     backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText
+    color: theme.palette.primary.contrastText,
+    '&:hover' : {
+        color: theme.palette.primary.contrastText,
+        backgroundColor: theme.palette.primary.main,
+    }
   }
 })
 


### PR DESCRIPTION
## Added styling to clip (it was not showing correct styles on click)

> Changed task-status-filter.js styles object

## Changed task-status-filter.js styles object in frontend folder

- task-status-filter.js

## https://github.com/worknenjoy/gitpay/issues/653

> Closes #653 

## Impacted Area

> Tasks page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Go to https://gitpay.me/#/tasks/all
- Change between other options like open, in progress etc and observe the styling

## Before
> <img width="539" alt="Screenshot 2020-08-29 at 16 17 34" src="https://user-images.githubusercontent.com/41532077/91635115-5041f700-ea13-11ea-9df6-84ead392da7f.png">

## After
<img width="632" alt="Screenshot 2020-08-29 at 16 17 41" src="https://user-images.githubusercontent.com/41532077/91635121-6059d680-ea13-11ea-87bc-22a7b49f671c.png">
