### PR TITLE
Fix Postgres does not loading correctly environment variables

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,5 +13,6 @@ services:
   db_test:
     image: postgres
     environment:      
-      POSTGRES_DB: gitpay_test
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=gitpay_test
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "3000:3000"
   db:
+    env_file:
+      - .env
     image: postgres    
-    environment:
-      POSTGRES_DB: gitpay_dev
     network_mode: host


### PR DESCRIPTION
## Description

> Fixed db service in docker-compose.yml doesn't loading required variables to Postgres image, cause of it the docker does not work correctly.

## Changes

- Added `env_file` property in db service as the others services in docker-compose.yml
- Added `POSTGRES_PASSWORD` variable in docker-compose.test.yml

## Impacted Area

> Development in docker

## Steps to test

- Just start the services on docker-compose.yml

## Before

![Screenshot from 2020-09-22 10-50-32](https://user-images.githubusercontent.com/26953960/93892444-ea1f5b80-fcc2-11ea-806e-de48745d11da.png)

## After

![Screenshot from 2020-09-22 11-11-51](https://user-images.githubusercontent.com/26953960/93893842-7a11d500-fcc4-11ea-969d-9fe02ea29b8b.png)
