### PR TITLE
Fix wrong user on task user

### DIFF
--- a/frontend/src/components/task/task-tabs.js
+++ b/frontend/src/components/task/task-tabs.js
@@ -382,7 +382,7 @@ class TaskTabs extends React.Component {
 
     const historyCreate = item => {
       const fields = item.fields.map((f, i) => {
-        if (f === 'userId') return `User: ${user.name || user.username}`
+        if (f === 'userId') return `User: ${task.data.user.name || task.data.user.username}`
         return `${f}: ${item.newValues[i]}`
       })
       return `A new issue was created with ${fields.join(', ')}`


### PR DESCRIPTION
## Description

> The task history tab was showing the wrong user on create. Was showing the logged in user.

## Changes

- Change the line to show the task user creator

## Issue

> Closes #518 

## Impacted Area

> Main page

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Create Task
- Other steps

## Before
> Screenshot from the state before
![image](https://user-images.githubusercontent.com/10778415/97481466-9fcd7200-1933-11eb-82e7-e7dcd8001cf5.png)


## After
> Screenshot from the state after your Pull Request
![image](https://user-images.githubusercontent.com/10778415/97481499-abb93400-1933-11eb-9c74-b6b73d05bec2.png)
