### PR TITLE
Fixing the unwanted page refresh from explore top bar button

### DIFF
--- a/frontend/src/components/topbar/topbar.js
+++ b/frontend/src/components/topbar/topbar.js
@@ -285,8 +285,7 @@ class TopBar extends Component {
   }
 
   handleViewTasks = () => {
-    window.location.href = '/#/tasks/open'
-    window.location.reload()
+    this.props.history.push('/tasks/open')
   }
 
   handleSignOut = () => {


### PR DESCRIPTION
## Description

> Changed window.location.href to use react history.

## Changes

- Explore top bar button.

## Issue

> Closes #802 

## Impacted Area

> Task list

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Import task
- Click the explore top bar button and see that will not trigger page refresh and will open correctly

## Before
> ![image](https://user-images.githubusercontent.com/21283066/114787509-5395b300-9d56-11eb-8df5-4adb32aaf5b5.png)

## After
> 
![image](https://user-images.githubusercontent.com/21283066/114787452-395bd500-9d56-11eb-9b73-0f723c03eb90.png)

