### PR TITLE
removing legacy_payments to capabilities

### DIFF
--- a/modules/users/userAccountCreate.js
+++ b/modules/users/userAccountCreate.js
@@ -23,10 +23,6 @@ module.exports = Promise.method(function userAccountCreate (userParameters) {
         requestedCapabilities.push('card_payments')
       }
 
-      if (userParameters.country !== 'GB') {
-        requestedCapabilities.push('legacy_payments')
-      }
-
       return stripe.accounts.create({
         type: 'custom',
         country: userParameters.country || 'US',


### PR DESCRIPTION
Removing `legacy_payments` to capabilities when creating an account