### PR TITLE
Issue #894

### DIFF
--- a/models/plan.js
+++ b/models/plan.js
@@ -13,7 +13,7 @@ module.exports = (sequelize, DataTypes) => {
       associate: (models) => {
         Plan.belongsTo(models.Order, { foreignKey: 'OrderId' })
       },
-      calFinalPrice: (price, plan) => {
+      calcFinalPrice: (price, plan) => {
         const percentages = { 'open source': 1.08, 'private': 1.18, 'full': 1.30 }
         return Math.round(Number((price * (percentages[plan])).toFixed(2)))
       }

--- a/modules/orders/orderBuilds.js
+++ b/modules/orders/orderBuilds.js
@@ -62,7 +62,7 @@ module.exports = Promise.method(function orderBuilds (orderParameters) {
         })
       }
       if (orderParameters.provider === 'paypal') {
-        const totalPrice = models.Plan.calFinalPrice(orderParameters.amount, orderParameters.plan)
+        const totalPrice = models.Plan.calcFinalPrice(orderParameters.amount, orderParameters.plan)
         return requestPromise({
           method: 'POST',
           uri: `${process.env.PAYPAL_HOST}/v1/oauth2/token`,

--- a/modules/tasks/taskUpdate.js
+++ b/modules/tasks/taskUpdate.js
@@ -27,14 +27,14 @@ const createSourceAndCharge = Promise.method((customer, orderParameters, order, 
       await order.updateAttributes({ couponId: couponValidation.id })
 
       // This means that the amount of discount provided by coupon is 100%
-      if (couponValidation.orderPrice === 0) {
+      if (couponValidation.orderPrice <= 0.5) {
         return orderUpdateAfterStripe(order, null, null, orderParameters, user, task, true)
       }
 
-      totalPrice = models.Plan.calFinalPrice(couponValidation.orderPrice, orderParameters.plan) * 100
+      totalPrice = models.Plan.calcFinalPrice(couponValidation.orderPrice, orderParameters.plan) * 100
     }
     else {
-      totalPrice = models.Plan.calFinalPrice(orderParameters.amount, orderParameters.plan) * 100
+      totalPrice = models.Plan.calcFinalPrice(orderParameters.amount, orderParameters.plan) * 100
     }
 
     return stripe.charges.create({


### PR DESCRIPTION
## Description

> Charges with an amount equal to zero are causing an error with the stripe request.

## Changes

- Changing function name calFinalPrice to calcFinalPrice on Plan's model
- Changing the conditional related to avoid a charge request to stripe with amount equals to zero

## Issue

> Closes #894

## Impacted Area

> Credit Card payment

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Create / log user
- Create Task
- Create a payment for the task created using credit card

## Before
> N/A

## After
> N/A
