### PR TITLE
Fix Task Assignment translation missing

### DIFF
--- a/frontend/src/components/task/task-assignment.js
+++ b/frontend/src/components/task/task-assignment.js
@@ -226,17 +226,20 @@ const TaskAssignment = (props) => {
     if (props.assignDialog) {
       return (
         <FormControl fullWidth>
-          <TextareaAutosize
-            id='interested-comment'
-            type='text'
-            placeholder='Tell about your interest in solve this task and any plan in mind'
-            rowsMin={ 8 }
-            maxLength={ 1000 }
-            value={ props.interestedComment }
-            onChange={ props.handleInputInterestedCommentChange }
+          <FormattedMessage id='task.bounties.interested.comment.value' defaultMessage='Tell about your interest in solve this task and any plan in mind' >
+            { placeholder => (
+              <TextareaAutosize
+                id='interested-comment'
+                type='text'
+                placeholder={ placeholder }
+                rowsMin={ 8 }
+                maxLength={ 1000 }
+                value={ props.interestedComment }
+                onChange={ props.handleInputInterestedCommentChange }
 
-          />
-
+              />
+            ) }
+          </FormattedMessage>
           <small style={ { fontFamily: 'Roboto', color: '#a9a9a9', marginTop: '10px', textAlign: 'right' } }>{ props.charactersCount + '/1000' }</small>
         </FormControl>
       )


### PR DESCRIPTION
## Description

The translation are missing in the task assignment text area

![image](https://user-images.githubusercontent.com/51221635/172082283-ea21675a-6953-46fb-88f2-4904fdab1446.png)

the website donth swith to portuguese in localhost, and generate this error in the console:

![image](https://user-images.githubusercontent.com/51221635/172082467-fb5117a9-860e-44e5-8a13-5389cf28419e.png)

i submitting this PR with the hotfix but will be better test in all languages before merging, please give me the instructions to test it or let's try in a staging environment


