### PR TITLE
slack link updated

### DIFF
--- a/frontend/src/components/topbar/topbar.js
+++ b/frontend/src/components/topbar/topbar.js
@@ -783,7 +783,7 @@ class TopBar extends Component {
                 <Grid container justify='center'>
                   <Grid item>
                     <Button
-                      href={ process.env.SLACK_CHANNEL_INVITE_LINK }
+                      href='https://join.slack.com/t/gitpay-workspace/shared_invite/zt-1j8yyotnp-EbA3OSuL7cJkZL_CgBW37g' target='_blank'
                       variant='outline'
                       size='medium'
                       color='secondary'


### PR DESCRIPTION
## Description

> Link to join slack channel updated.

## Changes

- topbar.js

## Issue

> #915 

## Impacted Area

> Top bar navigation

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- Click on "join our slack" at topbar to confirm it's redirecting to the right channel

## Before
> Screenshot from the state before

## After
> Screenshot from the state after your Pull Request
