### PR TITLE
Fix docker compose

### DIFF
--- a/.docker/backend.dockerfile
+++ b/.docker/backend.dockerfile
@@ -1,0 +1,6 @@
+FROM node:17
+EXPOSE 3000
+COPY . /gitpay
+WORKDIR /gitpay
+RUN npm install
+CMD ["npm", "run", "start"]

--- a/.docker/frontend.dockerfile
+++ b/.docker/frontend.dockerfile
@@ -1,0 +1,6 @@
+FROM node:17.3.0
+EXPOSE 8082
+COPY ./frontend /gitpay/frontend
+WORKDIR /gitpay/frontend
+RUN npm install
+CMD ["npm", "run", "dev"]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules
+
+.*

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
     "username": "postgres",
     "password": "postgres",
     "database": "gitpay_dev",
-    "host": "127.0.0.1",
+    "host": "db",
     "port": 5432,
     "dialect": "postgres",
     "logging": false,
@@ -13,8 +13,8 @@
     "username": "postgres",
     "password": "postgres",
     "database": "gitpay_test",
-    "host": "127.0.0.1",
-    "port": 5432,
+    "host": "db_test",
+    "port": 5433,
     "dialect": "postgres",
     "logging": false
   } 

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -6,7 +6,7 @@ const databaseDev = {
   username: 'postgres',
   password: 'postgres',
   database: 'gitpay_dev',
-  host: '127.0.0.1',
+  host: 'db',
   port: 5432,
   dialect: 'postgres',
   logging: false
@@ -16,8 +16,8 @@ const databaseTest = {
   username: 'postgres',
   password: 'postgres',
   database: 'gitpay_test',
-  host: '127.0.0.1',
-  port: 5432,
+  host: 'db_test',
+  port: 5433,
   dialect: 'postgres',
   logging: false
 }
@@ -27,7 +27,7 @@ const databaseProd = {
   password: null,
   database: process.env.DATABASE_URL,
   schema: 'public',
-  host: '127.0.0.1',
+  host: 'db',
   port: 5432,
   dialect: 'postgres',
   protocol: 'postgres'
@@ -38,7 +38,7 @@ const databaseStaging = {
   password: null,
   database: process.env.DATABASE_URL,
   schema: 'public',
-  host: '127.0.0.1',
+  host: 'db',
   port: 5432,
   dialect: 'postgres',
   protocol: 'postgres'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,18 +1,33 @@
-version: '3.7'
-
 services:
   backend_test:
-    image: node:8.6
-    command: sh -c "npm install && npm run migrate-test && npm run test"
-    working_dir: /gitpay
-    volumes: 
-      - .:/gitpay    
+    container_name: backend_test
+    image: backend
+    command: bash -c "npm run migrate-test  && npm run seed-test && npm run test"
+    build:
+      context: .
+      dockerfile: .docker/backend.dockerfile
     environment:
       - NODE_ENV=test
-    network_mode: host
-  db_test:
-    image: postgres
-    environment:      
+      - POSTGRES_PORT=5433
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=gitpay_test
-    network_mode: host
+      - OAUTH_CLIENT_ID=fakeid
+      - OAUTH_CLIENT_SECRET=fakesecret
+      - PAYPAL_HOST="https://api.sandbox.paypal.com"
+
+    pull_policy: missing
+    depends_on:
+      - db_test
+    restart: "no"
+    ports:
+      - "3001:3000"
+
+  db_test:
+    container_name: db_test
+    image: postgres
+    pull_policy: missing
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=gitpay_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,36 @@
-version: '3.7'
-
 services:
-  frontend:
-    image: node:8.6
-    command: sh -c "npm install && npm run dev"
-    working_dir: /gitpay/frontend
-    volumes: 
-      - .:/gitpay
-    network_mode: host
-    ports:
-      - "8082:8082"
-    expose:
-      - "8082"
-  backend:
+  db:
+    container_name: db
     env_file:
       - .env
-    image: node:8.6
-    command: sh -c "npm install && npm run migrate && npm run start"
-    working_dir: /gitpay
-    volumes: 
-      - .:/gitpay
-    network_mode: host
+    image: postgres
+    pull_policy: missing
+    ports:
+      - "5432:5432"
+
+  backend:
+    container_name: backend
+    image: backend
+    env_file:
+      - .env
+    command: bash -c 'npm run migrate && npm run seed && npm run start'
+    build:
+      context: .
+      dockerfile: .docker/backend.dockerfile
+    pull_policy: missing
     ports:
       - "3000:3000"
-  db:
-    env_file:
-      - .env
-    image: postgres    
-    network_mode: host
+    restart: always
+    depends_on:
+      - db
+
+  frontend:
+    container_name: frontend
+    build:
+      context: .
+      dockerfile: .docker/frontend.dockerfile
+    pull_policy: missing
+    ports:
+      - "8082:8082"
+    depends_on:
+      - backend


### PR DESCRIPTION
# Add fixes for docker compose deployment

Resolves #1010 

## Description

Improve docker-compose set up.

## Solution

- Backend and frontend images are built with their own Dockerfiles:  This captures as much of the installation/set up as possible during the build stage. This should speed up development as only changes to dependencies should necessitate reinstalling the npm deps. As an alternative the docker-compose watch functionality can sync the required
- Ignore rather than bind mount node_modules into the docker image: The node_modules should be for the local host if such an installation exists. In the docker image these directories will be specific to that environment. Updating these requires an image rebuild
- Note that this deployment will work on apple silicon too; however, DOCKER_DEFAULT_PLATFORM must be set to "linux/amd64". PhantomJS is not distributed for linux arm64 so a container running on the native chip architecture doesn't work.


### Remaining (potential) issues

- I have changed the hosts to db/db_test, which is available in the docker network (network mode of "host" only works on linux). I'm not sure this is the best location to change this and what API_HOST should be set to. The deployment seems to be working for me as far as I can tell though.
-  Currently some files are invalidating the docker build cache which slows down development. Hopefully the culprits can be found and then running `docker compose up --build` will only trigger a rerun of `npm install` if the appropriate files have changed
- Currently the test compose file is failing. Something is misconfigured and the migration fails. I can't spot what it is though. It might be better to use the same images/configuration for the tests.

