### PR TITLE
Making Wallet order add a fee when pay

### DIFF
--- a/frontend/src/components/design-library/templates/payment-drawer/payment-drawer.tsx
+++ b/frontend/src/components/design-library/templates/payment-drawer/payment-drawer.tsx
@@ -98,7 +98,7 @@ const PaymentDrawer = ({ tabs, open, onClose, onChangePrice, plan, title, pickup
               secondaryText={pickupTagListMessagesSecondaryText}
               onPickItem={onPickItem}
             />
-            <PricePlan plan={plan} price={price} onChange={onChangePrice} />
+            <PricePlan plan={tabValue !== 'wallet' ? plan : false} price={price} onChange={onChangePrice} />
             <div>
               <Tabs
                 value={tabValue}

--- a/frontend/src/components/profile/components/payments/add-funds-form-drawer.tsx
+++ b/frontend/src/components/profile/components/payments/add-funds-form-drawer.tsx
@@ -39,6 +39,15 @@ const AddFundsFormDrawer = ({ intl, open, onClose, customer, onPay }) => {
       onChangePrice={(price) => pickTaskPrice(price)}
       open={open}
       onClose={onClose}
+      plan={{
+        fee: 8,
+        category: <FormattedMessage id='actions.task.payment.plan.opensource' defaultMessage='Open Source' />,
+        title: <FormattedMessage id='actions.task.payment.plan.opensource.info' defaultMessage='For Open Source Project' />,
+        items: [
+          <FormattedMessage id='actions.task.payment.plan.bullet.public' defaultMessage='For Public Projects' />,
+          <FormattedMessage id='actions.task.payment.plan.bullet.basic' defaultMessage='Basic Campaign' />,
+        ],
+      }}
       tabs={[
         {
           default: true,

--- a/frontend/src/components/profile/components/payments/add-funds-invoice-tab.tsx
+++ b/frontend/src/components/profile/components/payments/add-funds-invoice-tab.tsx
@@ -11,7 +11,7 @@ const AddFundsInvoiceTab = ({
 }) => {
 
   const onInvoicePayment = async () => {
-    await onPay(price)
+    await onPay(priceAfterFee)
   }
 
   useEffect(() => {
@@ -20,7 +20,7 @@ const AddFundsInvoiceTab = ({
 
   return (
     <InvoicePayment 
-      price={price}
+      price={priceAfterFee}
       customer={customer}
       onInvoicePayment={onInvoicePayment}
       onInfoClick={ () => history.push('/profile/user-account/customer') }

--- a/frontend/src/components/task/payment/methods/wallet/payment-method-wallet-tab.tsx
+++ b/frontend/src/components/task/payment/methods/wallet/payment-method-wallet-tab.tsx
@@ -71,7 +71,7 @@ const PaymentMethodWalletTab = ({
         className={classes.btnPayment}
       >
         <FormattedMessage id='task.payment.wallet.action' defaultMessage='Pay {amount} with your Wallet' values={{
-          amount: formatCurrency(priceAfterFee)
+          amount: formatCurrency(price)
         }} />
       </Button>
     </div>

--- a/models/wallet.js
+++ b/models/wallet.js
@@ -32,7 +32,7 @@ module.exports = (sequelize, DataTypes) => {
       },
     })
     const balance = orders.reduce((acc, order) => {
-      return acc.plus(order.amount)
+      return acc.plus(order.amount/1.08)
     }, new Decimal(0))
     return balance
   }
@@ -47,7 +47,7 @@ module.exports = (sequelize, DataTypes) => {
       }
     })
     const balance = orders.reduce((acc, order) => {
-      return acc.plus(order.amount * 1.08)
+      return acc.plus(order.amount)
     }, new Decimal(0))
     return balance
   }

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -148,7 +148,7 @@ describe('orders', () => {
           userId: user.body.id
         }
       })
-      expect(wallet.balance).to.equal('184.00')
+      expect(wallet.balance).to.equal('170.37')
     })
 
     xit('should create a new paypal order', (done) => {

--- a/test/walletOrder.test.js
+++ b/test/walletOrder.test.js
@@ -105,7 +105,7 @@ describe('WalletOrder', () => {
       });
       const walletOrder = await models.WalletOrder.create({
         walletId: wallet.id,
-        amount: 100
+        amount: 108
       });
       const res = await agent
         .put(`/wallets/orders/${walletOrder.id}`)
@@ -119,7 +119,7 @@ describe('WalletOrder', () => {
 
       expect(res.body).to.exist;
       expect(res.body.id).to.exist;
-      expect(res.body.amount).to.equal('100');
+      expect(res.body.amount).to.equal('108');
       expect(res.body.status).to.equal('paid');
       expect(res.body.walletId).to.equal(wallet.id);
 
@@ -141,7 +141,7 @@ describe('WalletOrder', () => {
       
       const walletOrder = await models.WalletOrder.create({
         walletId: wallet.id,
-        amount: 100
+        amount: 108
       });
       await agent
         .put(`/wallets/orders/${walletOrder.id}`)
@@ -155,7 +155,7 @@ describe('WalletOrder', () => {
 
       const walletOrder2 = await models.WalletOrder.create({
         walletId: wallet.id,
-        amount: 100
+        amount: 108
       });
       await agent
         .put(`/wallets/orders/${walletOrder2.id}`)
@@ -169,7 +169,7 @@ describe('WalletOrder', () => {
 
       const walletOrder3 = await models.WalletOrder.create({
         walletId: wallet.id,
-        amount: 100
+        amount: 108
       });
       await agent
         .put(`/wallets/orders/${walletOrder3.id}`)
@@ -198,7 +198,7 @@ describe('WalletOrder', () => {
       });
       const walletOrder = await models.WalletOrder.create({
         walletId: wallet.id,
-        amount: 100,
+        amount: 108,
         status: 'pending'
       });
       const res = await agent


### PR DESCRIPTION
This pull request includes changes to the payment and wallet handling logic in the frontend and backend, as well as corresponding updates to the tests. The most important changes involve modifying how prices and fees are handled and updating the wallet balance calculations.

### Payment and Wallet Handling Improvements:

* [`frontend/src/components/design-library/templates/payment-drawer/payment-drawer.tsx`](diffhunk://#diff-ac8540cbed094e28d54202f1fcaa1ad45a50b54e2a439e7dcb8f82f10b5fce1eL101-R101): Updated the `PricePlan` component to conditionally pass the `plan` prop based on the `tabValue` to handle different payment scenarios.
* [`frontend/src/components/profile/components/payments/add-funds-form-drawer.tsx`](diffhunk://#diff-a2383530ea7160c15d3d05d7be3bb01f1dfd996d8420db4556fc74558acd42a0R42-R50): Added a new `plan` object to the `AddFundsFormDrawer` component to include additional information about the payment plan.
* [`frontend/src/components/profile/components/payments/add-funds-invoice-tab.tsx`](diffhunk://#diff-e3132b505238c56c6bb410f9cb862c3ea282d7222b39c5983b62cd2bd9718259L14-R14): Changed the `onPay` function to use `priceAfterFee` instead of `price` to ensure the fee is included in the payment process. [[1]](diffhunk://#diff-e3132b505238c56c6bb410f9cb862c3ea282d7222b39c5983b62cd2bd9718259L14-R14) [[2]](diffhunk://#diff-e3132b505238c56c6bb410f9cb862c3ea282d7222b39c5983b62cd2bd9718259L23-R23)
* [`frontend/src/components/task/payment/methods/wallet/payment-method-wallet-tab.tsx`](diffhunk://#diff-b891ab86f9713ca4709c9be0e528412229baf208e3ffd44ae805625a2fc40402L74-R74): Modified the payment button to display the correct amount by using `price` instead of `priceAfterFee`.

### Wallet Balance Calculation Adjustments:

* [`models/wallet.js`](diffhunk://#diff-7407a2939ddbcb1190b1f0ac83e103cdee9a94def01e1167bd1984d2b9fb5b72L35-R35): Updated the balance calculation logic to correctly apply or remove the fee multiplier when summing order amounts. [[1]](diffhunk://#diff-7407a2939ddbcb1190b1f0ac83e103cdee9a94def01e1167bd1984d2b9fb5b72L35-R35) [[2]](diffhunk://#diff-7407a2939ddbcb1190b1f0ac83e103cdee9a94def01e1167bd1984d2b9fb5b72L50-R50)

### Test Updates:

* [`test/order.test.js`](diffhunk://#diff-ff8e3c61e05ddfef8ce98c652bc8f547120c7cd7c63c88d8605b871d40747103L151-R151): Adjusted the expected wallet balance to reflect the changes in fee handling.
* [`test/walletOrder.test.js`](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL108-R108): Updated the `WalletOrder` tests to use the correct amount values that include the fee. [[1]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL108-R108) [[2]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL122-R122) [[3]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL144-R144) [[4]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL158-R158) [[5]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL172-R172) [[6]](diffhunk://#diff-d5f57c8c3840de409b5f7d9ed06cd555a0f193fb98171a0adde13397c890709fL201-R201)