### PR TITLE
adding bank account status

### DIFF
--- a/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.stories.tsx
+++ b/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.stories.tsx
@@ -1,0 +1,58 @@
+import BankAccountStatus from './bank-account-status';
+
+const meta = {
+  title: 'Design Library/Atoms/Status/Account/BankAccountStatus',
+  component: BankAccountStatus,
+  args: {
+    status: 'Active',
+    color: 'green',
+  },
+  argTypes: {
+    status: { control: 'text' },
+    color: { control: 'color' },
+  },
+};
+
+export default meta;
+
+export const Default = {
+  args: {
+    status: 'new',
+  },
+};
+
+export const Validated = {
+  args: {
+    status: 'validated',
+  },
+};
+
+export const Verified = {
+  args: {
+    status: 'verified',
+  },
+};
+
+export const Invalid = {
+  args: {
+    status: 'errored',
+  },
+};
+
+export const VerificationFailed = {
+  args: {
+    status: 'verification_failed',
+  },
+};
+
+export const Unknown = {
+  args: {
+    status: 'unknown',
+  },
+};
+export const Loading = {
+  args: {
+    status: 'new',
+    completed: false,
+  },
+};

--- a/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { green, orange } from '@material-ui/core/colors';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { 
+  CheckCircleOutlineTwoTone as ActiveIcon,
+  HelpOutline as QuestionInfoIcon,
+  NotInterested as InactiveIcon
+} from '@material-ui/icons';
+
+import BaseStatus from '../../base-status/base-status';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    pending: {
+      backgroundColor: orange[500],
+      color: theme.palette.common.white,
+    },
+    active: {
+      backgroundColor: green[500],
+      color: theme.palette.common.white,
+    },
+    inactive: {
+      backgroundColor: theme.palette.grey[400],
+      color: theme.palette.common.white,
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    },
+  }),
+);
+
+interface BankAccountStatusProps {
+  status: string;
+  completed?: boolean; // Optional prop to indicate if the status is completed
+}
+
+const BankAccountStatus: React.FC<BankAccountStatusProps> = ({
+  status,
+  completed = true, // Default to true if not provided
+}) => {
+  const classes = useStyles();
+  
+  const statusList = [
+    { status: 'new', label: 'Active', color: 'active', icon: <ActiveIcon className={classes.active} /> },
+    { status: 'validated', label: 'Active', color: 'active', icon: <ActiveIcon className={classes.active} /> },
+    { status: 'verified', label: 'Active', color: 'active', icon: <ActiveIcon className={classes.active} /> },
+    { status: 'errored', label: 'Inactive', color: 'inactive', icon: <InactiveIcon className={classes.inactive} />, message: 'Your bank account is inactive. Please complete all required information. If your account remains inactive, contact support at issues@gitpay.me for assistance.' },
+    { status: 'verification_failed', label: 'Inactive', color: 'inactive', icon: <InactiveIcon className={classes.inactive} />, message: 'Your bank account is inactive. Please complete all required information. If your account remains inactive, contact support at issues@gitpay.me for assistance.' },
+    { status: 'unknown', label: 'Unknown', color: 'unknown', icon: <QuestionInfoIcon className={classes.unknown} />, message: 'Your status is unknown. Please check back later.' },
+  ];
+
+  return (
+    <BaseStatus
+      status={status}
+      statusList={statusList}
+      classes={classes}
+      completed={completed}
+    />
+  )
+};
+export default BankAccountStatus;

--- a/frontend/src/components/design-library/atoms/status/base-status/base-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/base-status/base-status.tsx
@@ -23,14 +23,15 @@ const BaseStatus = ({ status, statusList, classes, completed = true }:statusProp
 
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
 
-  const currentStatus = statusList.find((item) => item.status === status)
+  const currentStatus = statusList.find((item) => item.status === status) || statusList.find((item) => item.status === 'unknown')
 
-  const { label = '', color, icon, message } = currentStatus;
+  const { label , color, icon, message } = currentStatus;
   
   // Custom delete icon with tooltip
   const deleteIconWithTooltip = (
+    message && 
     <Tooltip
-      title={message || 'Click for more information'}
+      title={message}
       open={tooltipOpen}
       onClose={() => setTooltipOpen(!tooltipOpen)}
       disableFocusListener
@@ -50,7 +51,7 @@ const BaseStatus = ({ status, statusList, classes, completed = true }:statusProp
     </Tooltip>
   );
 
-  const extraProps = status === 'active' ? {} : { 
+  const extraProps = message && { 
     deleteIcon: deleteIconWithTooltip,
     onDelete: () => setTooltipOpen(true)
   };

--- a/frontend/src/components/design-library/molecules/headers/profile-main-header/profile-main-header.stories.tsx
+++ b/frontend/src/components/design-library/molecules/headers/profile-main-header/profile-main-header.stories.tsx
@@ -18,20 +18,19 @@ export const WithStatus = Template.bind({});
 WithStatus.args = {
   title: 'Profile Header with Status',
   subtitle: 'This is a subtitle with status',
-  status: 'active',
+  aside: <span>Status: Active</span>,
 }
 
 export const WithPendingStatus = Template.bind({});
 WithPendingStatus.args = {
   title: 'Profile Header with Pending Status',
   subtitle: 'This is a subtitle with pending status',
-  status: 'pending',
+  aside: <span>Status: Pending</span>,
 };
 
 export const Loading = Template.bind({});
 Loading.args = {
   title: 'Loading Profile Header',
   subtitle: 'This is a loading state',
-  status: 'pending',
   completed: false,
 };

--- a/frontend/src/components/design-library/molecules/headers/profile-main-header/profile-main-header.tsx
+++ b/frontend/src/components/design-library/molecules/headers/profile-main-header/profile-main-header.tsx
@@ -5,20 +5,18 @@ import MainTitle from '../../../atoms/typography/main-title/main-title';
 type ProfileMainHeaderProps = {
   title: string | React.ReactNode; // Allow title to be a string or a React node
   subtitle: string | React.ReactNode; // Allow subtitle to be a string or a React node
-  status?: string; // Optional status prop
+  aside?: React.ReactNode; // Optional prop for additional content on the right side
   completed?: boolean; // Optional prop to indicate if the status is completed
 };
 
-const ProfileMainHeader = ({ title, subtitle, status, completed }:ProfileMainHeaderProps) => {
+const ProfileMainHeader = ({ title, subtitle, aside }:ProfileMainHeaderProps) => {
   return (
     <div style={{marginBottom: 20, display: 'flex', flexDirection: 'row', justifyContent: 'space-between'}}>
       <MainTitle
         title={title}
         subtitle={subtitle}
       />
-      {status && (
-        <ProfileHeaderStatus status={status} completed={completed} />
-      )}
+      {aside && aside}
     </div>
   );
 }

--- a/frontend/src/components/design-library/molecules/headers/profile-secondary-header/profile-secondary-header.stories.tsx
+++ b/frontend/src/components/design-library/molecules/headers/profile-secondary-header/profile-secondary-header.stories.tsx
@@ -18,14 +18,14 @@ export const WithStatus = Template.bind({});
 WithStatus.args = {
   title: 'Profile Header with Status',
   subtitle: 'This is a subtitle with status',
-  status: 'active',
+  aside: <span>Status: Active</span>,
 }
 
 export const WithPendingStatus = Template.bind({});
 WithPendingStatus.args = {
   title: 'Profile Header with Pending Status',
   subtitle: 'This is a subtitle with pending status',
-  status: 'pending',
+  aside: <span>Status: Pending</span>,
 };
 
 export const Loading = Template.bind({});

--- a/frontend/src/components/design-library/molecules/headers/profile-secondary-header/profile-secondary-header.tsx
+++ b/frontend/src/components/design-library/molecules/headers/profile-secondary-header/profile-secondary-header.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
-import ProfileHeaderStatus from '../../../atoms/status/account-status/account-holder-status/account-holder-status';
+import AccountHolderStatus from '../../../atoms/status/account-status/account-holder-status/account-holder-status';
 import SecondaryTitle from '../../../atoms/typography/secondary-title/secondary-title';
 
 type ProfileSecondaryHeaderProps = {
   title: string | React.ReactNode; // Allow title to be a string or a React node
   subtitle: string | React.ReactNode; // Allow subtitle to be a string or a React node
-  status?: string; // Optional status prop
-  completed?: boolean; // Optional prop to indicate if the status is completed
+  aside?: React.ReactNode; // Optional prop for additional content on the right side
 };
 
-const ProfileSecondaryHeader = ({ title, subtitle, status, completed }:ProfileSecondaryHeaderProps) => {
+const ProfileSecondaryHeader = ({ title, subtitle, aside }:ProfileSecondaryHeaderProps) => {
   return (
     <div style={{marginBottom: 20, display: 'flex', flexDirection: 'row', justifyContent: 'space-between'}}>
       <SecondaryTitle
         title={title}
         subtitle={subtitle}
       />
-      {status && (
-        <ProfileHeaderStatus status={status} completed={completed} />
-      )}
+      {aside && aside}
     </div>
   );
 }

--- a/frontend/src/components/design-library/organisms/forms/account-details-form/account-details-form.tsx
+++ b/frontend/src/components/design-library/organisms/forms/account-details-form/account-details-form.tsx
@@ -8,6 +8,7 @@ import AddressInformationForm from '../../../molecules/form-section/address-info
 import AcceptTermsField from '../../../atoms/inputs/fields/accept-terms-field/accept-terms-field';
 import Alert from '../../../atoms/alerts/alert/alert';
 import ProfileSecondaryHeader from '../../../molecules/headers/profile-secondary-header/profile-secondary-header';
+import AccountHolderStatus from '../../../atoms/status/account-status/account-holder-status/account-holder-status';
 
 const errorMapping = {
   'individual[dob][day]': 'Invalid day of birth',
@@ -42,8 +43,12 @@ const AccountDetailsForm = ({
       <ProfileSecondaryHeader
         title={<FormattedMessage id='payout-settings.bank-account-holder' defaultMessage='Account holder details' />}
         subtitle={<FormattedMessage id='payout-settings.bank-account-holder.description' defaultMessage='Please provide your information to activate your bank account.' />}
-        status={accountHolderStatus}
-        completed={completed}
+        aside={
+          <AccountHolderStatus
+            status={accountHolderStatus}
+            completed={completed}
+          />
+        }
       />
       {error.raw && (
         <Alert

--- a/frontend/src/components/design-library/organisms/forms/bank-account-form/bank-account-form.tsx
+++ b/frontend/src/components/design-library/organisms/forms/bank-account-form/bank-account-form.tsx
@@ -3,15 +3,16 @@ import { Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { FormattedMessage } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
-import AccountTypeField from '../../../../design-library/atoms/inputs/fields/account-type-field/account-type-field';
-import CountrySelectField from '../../../../design-library/atoms/inputs/fields/country-select-field/country-select-field';
-import BankCurrencyField from '../../../../design-library/atoms/inputs/fields/bank-currency-field/bank-currency-field';
-import BankSelectField from '../../../../design-library/atoms/inputs/fields/bank-select-field/bank-select-field';
-import Field from '../../../../design-library/atoms/inputs/fields/field/field';
-import Button from '../../../../design-library/atoms/buttons/button/button';
+import AccountTypeField from '../../../atoms/inputs/fields/account-type-field/account-type-field';
+import CountrySelectField from '../../../atoms/inputs/fields/country-select-field/country-select-field';
+import BankCurrencyField from '../../../atoms/inputs/fields/bank-currency-field/bank-currency-field';
+import BankSelectField from '../../../atoms/inputs/fields/bank-select-field/bank-select-field';
+import Field from '../../../atoms/inputs/fields/field/field';
+import Button from '../../../atoms/buttons/button/button';
 import BankAccountNumberForm from '../../../molecules/form-section/bank-account-number-form/bank-account-number-form';
-import Alert from '../../../../design-library/atoms/alerts/alert/alert';
-
+import Alert from '../../../atoms/alerts/alert/alert';
+import ProfileSecondaryHeader from '../../../molecules/headers/profile-secondary-header/profile-secondary-header';
+import BankAccountStatus from '../../../atoms/status/account-status/bank-account-status/bank-account-status';
 
 const errorMapping = {
   'external_account[account_number]': 'Invalid account number or iban',
@@ -40,7 +41,7 @@ const BankAccountForm = ({
 }) => {
   const classes = useStyles();
   const { data, completed, error = {} } = bankAccount || {};
-  const { id, account_holder_name, account_holder_type, account_number, routing_number, last4, country, currency } = data || {};
+  const { id, status, account_holder_name, account_holder_type, account_number, routing_number, last4, country, currency } = data || {};
   const [ ibanMode, setIbanMode ] = React.useState(false);
   const [ currentCountry, setCurrentCountry ] = React.useState(country);
 
@@ -51,6 +52,13 @@ const BankAccountForm = ({
 
   return (
     <form onSubmit={onSubmit}>
+      <ProfileSecondaryHeader
+        title={<FormattedMessage id='payout-settings.bank-account-info.title' defaultMessage='Bank account information' />}
+        subtitle={<FormattedMessage id='payout-settings.bank-account-info.description' defaultMessage='Please provide your bank account activation to receive payouts' />}
+        aside={status && 
+          <BankAccountStatus status={status} completed={completed} />
+        }
+      />
       {error.raw && (
         <Alert
           severity="error"

--- a/frontend/src/components/design-library/pages/private/payout-settings-bank-account-info/payout-settings-bank-account-info.tsx
+++ b/frontend/src/components/design-library/pages/private/payout-settings-bank-account-info/payout-settings-bank-account-info.tsx
@@ -1,6 +1,4 @@
 import React from 'react'
-import { FormattedMessage } from 'react-intl';
-import ProfileHeader from '../../../molecules/headers/profile-main-header/profile-main-header';
 import BankAccountForm from '../../../organisms/forms/bank-account-form/bank-account-form'
 
 const PayoutSetingsBankAccountHolder = ({
@@ -12,19 +10,13 @@ const PayoutSetingsBankAccountHolder = ({
 }) => {
   
   return (
-    <>
-      <ProfileHeader
-        title={<FormattedMessage id='payout-settings.bank-account-info.title' defaultMessage='Bank account information' />}
-        subtitle={<FormattedMessage id='payout-settings.bank-account-info.description' defaultMessage='Please provide your bank account activation to receive payouts' />}
-      />
-      <BankAccountForm
-        bankAccount={bankAccount}
-        user={user}
-        countries={countries}
-        onSubmit={onSubmit}
-        onChangeBankCode={onChangeBankCode}
-      />
-    </>
+    <BankAccountForm
+      bankAccount={bankAccount}
+      user={user}
+      countries={countries}
+      onSubmit={onSubmit}
+      onChangeBankCode={onChangeBankCode}
+    />
   );
 }
 


### PR DESCRIPTION
This pull request introduces a new `BankAccountStatus` component and integrates it into various parts of the application, replacing the previous `status` prop in header components with a more flexible `aside` prop. It also includes updates to forms and headers to improve the handling of account and bank statuses. The most significant changes are grouped below:

### New Component: `BankAccountStatus`
* Created the `BankAccountStatus` component to display the status of a bank account with visual indicators and optional messages. It uses Material-UI icons and styles for different statuses, such as `new`, `validated`, `verified`, `errored`, `verification_failed`, and `unknown`.
* Added a storybook file for `BankAccountStatus` to showcase its different states and configurations.

### Header Components Refactor
* Replaced the `status` prop in `ProfileMainHeader` and `ProfileSecondaryHeader` with a new `aside` prop, allowing more flexible content (e.g., status components) to be displayed on the right side of the headers. [[1]](diffhunk://#diff-857f26c011502b6d378aa8d3aeb905b2262d76e73921025d2c4fcfda429e5e2eL8-R19) [[2]](diffhunk://#diff-86800bc3a9f80f7b0249bb566b78d7d3b04ac5a31519efc2ac902d4459025df2L2-R18)
* Updated storybook files for `ProfileMainHeader` and `ProfileSecondaryHeader` to reflect the new `aside` prop usage. [[1]](diffhunk://#diff-f1eb4b1d1ffcc1d27a57c29ea77f1c6e9bf4459f6fcfe0c9ff30a4afa992365dL21-L35) [[2]](diffhunk://#diff-557f6ece9da054ddb8d879cbb3bd2beeedf095b58b757d0b83a11cb898a69ec3L21-R28)

### Integration of `BankAccountStatus` and `AccountHolderStatus`
* Integrated `BankAccountStatus` into the `BankAccountForm` component to display the bank account's current status.
* Integrated `AccountHolderStatus` into the `AccountDetailsForm` component to display the account holder's status.

### Updates to `BaseStatus` Component
* Enhanced the `BaseStatus` component to handle unknown statuses gracefully by defaulting to an "unknown" status if the provided status is not found in the list.
* Simplified the logic for adding a delete icon tooltip by only including it when a message is present.

### Removal of Redundant Profile Header
* Removed the redundant `ProfileHeader` from the `PayoutSettingsBankAccountInfo` page, as the `ProfileSecondaryHeader` now handles the header functionality with the integrated `BankAccountStatus`. [[1]](diffhunk://#diff-c7f9c651bd6593afef027d41f641266fb54e50d6e0b127e06d0bb94f6b6a8307L2-L3) [[2]](diffhunk://#diff-c7f9c651bd6593afef027d41f641266fb54e50d6e0b127e06d0bb94f6b6a8307L15-L27)