### PR TITLE
Refactor checkbox terms styles

### DIFF
--- a/frontend/src/components/design-library/atoms/inputs/checkbox-terms/checkbox-terms.styles.ts
+++ b/frontend/src/components/design-library/atoms/inputs/checkbox-terms/checkbox-terms.styles.ts
@@ -1,0 +1,12 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  termsLabel: {
+    paddingTop: 0,
+  },
+  checkbox: {
+    paddingRight: 5,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/inputs/checkbox-terms/checkbox-terms.tsx
+++ b/frontend/src/components/design-library/atoms/inputs/checkbox-terms/checkbox-terms.tsx
@@ -1,18 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Checkbox, FormControlLabel, Grid, Link, Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import useStyles from './checkbox-terms.styles';
 import TermsDialog from './terms-dialog';
 // import { on } from 'events';
 
-const useStyles = makeStyles(() => ({
-  termsLabel: {
-    paddingTop: 0,
-  },
-  checkbox: {
-    paddingRight: 5,
-  },
-}));
 
 const CheckboxTerms = ({ onAccept }) => {
   const classes = useStyles();


### PR DESCRIPTION
## Summary
- extract `checkbox-terms` makeStyles into a new file
- update `checkbox-terms` component to import styles

## Testing
- `npm test` *(fails: cross-env not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_683f70887f60832bb35b98bfc34472ed