### PR TITLE
Refactor atoms styles

### DIFF
--- a/frontend/src/components/design-library/atoms/alerts/account-requirements/account-requirements.styles.ts
+++ b/frontend/src/components/design-library/atoms/alerts/account-requirements/account-requirements.styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  alert: {
+    marginBottom: 20,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/alerts/account-requirements/account-requirements.tsx
+++ b/frontend/src/components/design-library/atoms/alerts/account-requirements/account-requirements.tsx
@@ -5,8 +5,10 @@ import ReactPlaceholder from 'react-placeholder';
 import { Alert } from '../alert/alert';
 import { validAccount } from '../../../../../utils/valid-account';
 import api from '../../../../../consts';
+import useStyles from './account-requirements.styles';
 
 const AccountRequirements = ({ user, account, intl, onClick }) => {
+  const classes = useStyles()
   const { completed = true } = account;
 
   const missingRequirements = () => {
@@ -29,7 +31,7 @@ const AccountRequirements = ({ user, account, intl, onClick }) => {
     !validAccount(user, account) ?
       <Alert
         completed={completed}
-        style={{ marginBottom: 20 }}
+        className={classes.alert}
         severity='warning'
         action={
           <Button

--- a/frontend/src/components/design-library/atoms/alerts/alert/alert.styles.ts
+++ b/frontend/src/components/design-library/atoms/alerts/alert/alert.styles.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  closeButton: {}
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/alerts/alert/alert.tsx
+++ b/frontend/src/components/design-library/atoms/alerts/alert/alert.tsx
@@ -1,15 +1,10 @@
 import React, { useState, useEffect } from 'react'
 import MuiAlert from '@material-ui/lab/Alert'
 import CloseIcon from '@material-ui/icons/Close'
-import { makeStyles } from '@material-ui/core/styles'
+import useStyles from './alert.styles'
 import { Button } from '@material-ui/core'
 import ReactPlacholder from 'react-placeholder'
 
-const useStyles = makeStyles((theme) => ({
-  closeButton: {
-    
-  },
-}))
 
 export const Alert = (props) => {
   const { onClose, alertKey = 'default', actions, dismissable = false, completed, ...rest } = props

--- a/frontend/src/components/design-library/atoms/alerts/simple-info/simple-info.styles.ts
+++ b/frontend/src/components/design-library/atoms/alerts/simple-info/simple-info.styles.ts
@@ -1,0 +1,21 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    paddingBottom: 10,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  iconCenter: {
+    verticalAlign: 'middle',
+    paddingRight: 5,
+    color: 'action',
+  },
+  text: {
+    color: 'gray',
+    marginTop: 5,
+    fontSize: 11,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/alerts/simple-info/simple-info.tsx
+++ b/frontend/src/components/design-library/atoms/alerts/simple-info/simple-info.tsx
@@ -1,27 +1,21 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import useStyles from './simple-info.styles'
 import {
   Info as InfoIcon
 } from '@material-ui/icons'
 import { Typography } from '@material-ui/core'
 
-const useStyles = makeStyles((theme) => ({
-  iconCenter: {
-    verticalAlign: 'middle',
-    paddingRight: 5
-  },
-}))
 
 export const SimpleInfo = ({ text }) => {
   const classes = useStyles()
 
   return (
-    <div style={{ paddingBottom: 10, display: 'flex', alignItems: 'center' }}>
+    <div className={classes.root}>
       <div>
-        <InfoIcon className={classes.iconCenter} style={{ color: 'action' }} />
+        <InfoIcon className={classes.iconCenter} />
       </div>
       <div>
-        <Typography variant='body2' gutterBottom style={{ color: 'gray', marginTop: 5, fontSize: 11 }}>
+        <Typography variant='body2' gutterBottom className={classes.text}>
           {text}
         </Typography>
       </div>

--- a/frontend/src/components/design-library/atoms/badges/payment-provider/payment-provider.styles.ts
+++ b/frontend/src/components/design-library/atoms/badges/payment-provider/payment-provider.styles.ts
@@ -1,0 +1,41 @@
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
+import { orange, green, blue } from '@material-ui/core/colors'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    card: {
+      backgroundColor: green[400],
+      color: theme.palette.common.white,
+      '& .MuiChip-icon': {
+        color: theme.palette.common.white,
+      },
+    },
+    invoice: {
+      backgroundColor: orange[600],
+      color: theme.palette.common.white,
+      '& .MuiChip-icon': {
+        color: theme.palette.common.white,
+      },
+    },
+    paypal: {
+      backgroundColor: blue[300],
+      color: theme.palette.common.white,
+    },
+    wallet: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+      '& .MuiChip-icon': {
+        color: theme.palette.common.white,
+      },
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[400],
+      color: theme.palette.common.white,
+      '& .MuiChip-icon': {
+        color: theme.palette.common.white,
+      },
+    },
+  })
+)
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/badges/payment-provider/payment-provider.tsx
+++ b/frontend/src/components/design-library/atoms/badges/payment-provider/payment-provider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import { createStyles, Theme } from '@material-ui/core/styles';
 import { orange, green, blue } from '@material-ui/core/colors';
 import { 
   CreditCard as CreditCardIcon,
@@ -12,42 +12,7 @@ import { paymentProviders, paymentSources } from '../../../../../consts'
 
 const logoPaypal = require('images/paypal-icon.png').default;
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    card: {
-      backgroundColor: green[400],
-      color: theme.palette.common.white,
-      '& .MuiChip-icon': {
-        color: theme.palette.common.white,
-      },
-    },
-    invoice: {
-      backgroundColor: orange[600],
-      color: theme.palette.common.white,
-      '& .MuiChip-icon': {
-        color: theme.palette.common.white,
-      },
-    },
-    paypal: {
-      backgroundColor: blue[300],
-      color: theme.palette.common.white
-    },
-    wallet: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white,
-      '& .MuiChip-icon': {
-        color: theme.palette.common.white,
-      },
-    },
-    unknown: {
-      backgroundColor: theme.palette.grey[400],
-      color: theme.palette.common.white,
-      '& .MuiChip-icon': {
-        color: theme.palette.common.white,
-      },
-    }
-  }),
-);
+import useStyles from './payment-provider.styles';
 
 type statusProps = {
   provider: string;

--- a/frontend/src/components/design-library/atoms/buttons/action-buttons/action-buttons.styles.ts
+++ b/frontend/src/components/design-library/atoms/buttons/action-buttons/action-buttons.styles.ts
@@ -1,0 +1,25 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  primaryWrapper: {
+    marginTop: 30,
+    marginBottom: 10,
+  },
+  primaryLabel: {
+    display: 'inline-block',
+    marginRight: 10,
+  },
+  secondaryContainer: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+  },
+  secondaryButton: {
+    marginRight: 5,
+  },
+  secondaryLabel: {
+    display: 'inline-block',
+    marginRight: 10,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/buttons/action-buttons/action-buttons.tsx
+++ b/frontend/src/components/design-library/atoms/buttons/action-buttons/action-buttons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Button } from '@material-ui/core';
+import useStyles from './action-buttons.styles';
 
 
 interface ActionButtonsProps {
@@ -10,6 +11,7 @@ interface ActionButtonsProps {
 
 const ActionButtons: React.FC<ActionButtonsProps> = ({ primary, secondary }) => {
   const [ currentKey, setCurrentKey ] = React.useState('');
+  const classes = useStyles();
 
   const actionClick = (key:string, onClick: any) => {
     setCurrentKey(key);
@@ -20,7 +22,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ primary, secondary }) => 
     <div>
       {primary?.map((action, index) => (
         <>
-          <div style={{ marginTop: 30, marginBottom: 10 }}>
+          <div className={classes.primaryWrapper}>
             <Button
               onClick={() => actionClick(action.key, action.onClick)}
               color='primary'
@@ -30,7 +32,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ primary, secondary }) => 
               disabled={action.disabled}
               endIcon={action.icon}
             >
-              <span style={{ display: 'inline-block', marginRight: 10 }}>
+              <span className={classes.primaryLabel}>
           <FormattedMessage id={action.label} />
               </span>
             </Button>
@@ -38,7 +40,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ primary, secondary }) => 
           {action.component && React.cloneElement(action.component, { open: action.key === currentKey, onClose: () => setCurrentKey('') })}
         </>
       ))}
-      <div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+      <div className={classes.secondaryContainer}>
         {secondary?.map((action, index) => (
           <>
             <Button
@@ -48,10 +50,10 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ primary, secondary }) => 
               variant='contained'
               disabled={action.disabled}
               fullWidth
-              style={{ marginRight: 5 }}
+              className={classes.secondaryButton}
               endIcon={action.icon}
             >
-              <span style={{ display: 'inline-block', marginRight: 10 }}>
+              <span className={classes.secondaryLabel}>
                 {action.label}
               </span>
             </Button>

--- a/frontend/src/components/design-library/atoms/buttons/button/button.styles.ts
+++ b/frontend/src/components/design-library/atoms/buttons/button/button.styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  progress: {
+    marginLeft: 10,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/buttons/button/button.tsx
+++ b/frontend/src/components/design-library/atoms/buttons/button/button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button as MaterialButton, CircularProgress } from '@material-ui/core';
+import useStyles from './button.styles';
 
 type ButtonProps = {
   type?: 'button' | 'submit' | 'reset';
@@ -20,6 +21,7 @@ const Button = ({
   completed,
   onClick,
 }:ButtonProps) => {
+  const classes = useStyles();
   return (
     <MaterialButton
       type={type}
@@ -29,7 +31,7 @@ const Button = ({
       onClick={onClick}
     >
       {label}
-      {!completed ? <CircularProgress style={{marginLeft: 10}} size={24} color="inherit" /> : <></>}
+      {!completed ? <CircularProgress className={classes.progress} size={24} color="inherit" /> : <></>}
     </MaterialButton>
   );
 }

--- a/frontend/src/components/design-library/atoms/buttons/import-issue-button/import-issue-button.styles.ts
+++ b/frontend/src/components/design-library/atoms/buttons/import-issue-button/import-issue-button.styles.ts
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  actionButtons: {},
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/buttons/import-issue-button/import-issue-button.tsx
+++ b/frontend/src/components/design-library/atoms/buttons/import-issue-button/import-issue-button.tsx
@@ -3,13 +3,8 @@ import Grid from '@material-ui/core/Grid'
 import Button from '@material-ui/core/Button'
 import ButtonGroup from '@material-ui/core/ButtonGroup'
 import { FormattedMessage } from 'react-intl'
-import { makeStyles } from '@material-ui/core/styles'
+import useStyles from './import-issue-button.styles'
 
-const useStyles = makeStyles((theme) => ({
-  actionButtons: {
-    
-  }
-}))
 
 export default function ImportIssueButton ({
   onAddIssueClick

--- a/frontend/src/components/design-library/atoms/buttons/provider-login-buttons/provider-login-buttons.styles.ts
+++ b/frontend/src/components/design-library/atoms/buttons/provider-login-buttons/provider-login-buttons.styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  buttonMargin: {
+    marginRight: 10,
+  },
+  textMargin: {
+    marginLeft: 10,
+  },
+  linkMargin: {
+    display: 'inline-box',
+    marginLeft: 5,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/buttons/provider-login-buttons/provider-login-buttons.tsx
+++ b/frontend/src/components/design-library/atoms/buttons/provider-login-buttons/provider-login-buttons.tsx
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography'
 import GithubLogo from 'images/github-logo.png'
 import BitbucketLogo from 'images/bitbucket-logo.png'
 import api from '../../../../../consts'
+import useStyles from './provider-login-buttons.styles'
 
 type ProviderLoginButtonsProps = {
   classes?: any,
@@ -18,7 +19,7 @@ type ProviderLoginButtonsProps = {
   disconnectGithub?: () => void
 }
 
-const ProviderLoginButtons = ({ 
+const ProviderLoginButtons = ({
   classes = {},
   contrast = false,
   hideExtra = false,
@@ -29,7 +30,8 @@ const ProviderLoginButtons = ({
   authorizeGithub,
   disconnectGithub
 }:ProviderLoginButtonsProps) => {
-  const styles = { 
+  const classesLocal = useStyles()
+  const styles = {
     textAlign: textPosition,
     marginBottom: 10
   } as React.CSSProperties;
@@ -46,7 +48,7 @@ return (
           <a href='#' onClick={(e) => {
             e.preventDefault();
             disconnectGithub();
-          }} style={{display: 'inline-box', marginLeft: 5}}>
+          }} className={classesLocal.linkMargin}>
             <FormattedMessage id='account.login.connect.provider.disconnect' defaultMessage='disconnect' />
           </a> }
         </Typography>
@@ -62,17 +64,17 @@ return (
     <div style={{ display: 'flex', justifyContent: position }}>
       <div>
         <Button
-          style={{ marginRight: 10 }}
-          {...authorizeGithub ? 
+          className={classesLocal.buttonMargin}
+          {...authorizeGithub ?
             { onClick: () => authorizeGithub() } :
-            { href: `${api.API_URL}/authorize/github`} 
+            { href: `${api.API_URL}/authorize/github`}
           }
           variant='contained'
           color='secondary'
           disabled={provider === 'github'}
         >
           <img width='16' src={GithubLogo} />
-          <span style={{marginLeft: 10}}>Github</span>
+          <span className={classesLocal.textMargin}>Github</span>
         </Button>
         <Button
           href={`${api.API_URL}/authorize/bitbucket`}
@@ -81,7 +83,7 @@ return (
           disabled={provider === 'bitbucket'}
         >
           <img width='16' src={BitbucketLogo} />
-          <span style={{marginLeft: 10}}>Bitbucket</span>
+          <span className={classesLocal.textMargin}>Bitbucket</span>
         </Button>
       </div>
     </div>

--- a/frontend/src/components/design-library/atoms/inputs/checkboxes/checkboxes.styles.ts
+++ b/frontend/src/components/design-library/atoms/inputs/checkboxes/checkboxes.styles.ts
@@ -1,0 +1,20 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  container: {
+    fontFamily: 'Roboto',
+    color: '#a9a9a9',
+  },
+  item: {
+    paddingBottom: 0,
+  },
+  starterCheckbox: {},
+  termsLabel: {
+    paddingTop: 0,
+  },
+  checkbox: {
+    paddingRight: 5,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/inputs/checkboxes/checkboxes.tsx
+++ b/frontend/src/components/design-library/atoms/inputs/checkboxes/checkboxes.tsx
@@ -6,26 +6,8 @@ import {
   GridSize
 } from '@material-ui/core';
 
-import { makeStyles } from '@material-ui/core/styles';
+import useStyles from './checkboxes.styles';
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    fontFamily: 'Roboto',
-    color: '#a9a9a9',
-  },
-  item: {
-    paddingBottom: 0,
-  },
-  starterCheckbox: {
-    // Add any specific styles for starterCheckbox if needed
-  },
-  termsLabel: {
-    paddingTop: 0,
-  },
-  checkbox: {
-    paddingRight: 5,
-  },
-}));
 
 type CheckboxesProps = {
   checkboxes: any;

--- a/frontend/src/components/design-library/atoms/inputs/fieldset/fieldset.styles.ts
+++ b/frontend/src/components/design-library/atoms/inputs/fieldset/fieldset.styles.ts
@@ -1,0 +1,19 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles((theme) => ({
+  legend: {
+    fontSize: 18,
+    fontWeight: 500,
+    color: theme.palette.primary.dark,
+  },
+  fieldset: {
+    border: `1px solid ${theme.palette.primary.light}`,
+    margin: '16px 0',
+  },
+  placeholder: {
+    width: '95%',
+    padding: 12,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/inputs/fieldset/fieldset.tsx
+++ b/frontend/src/components/design-library/atoms/inputs/fieldset/fieldset.tsx
@@ -1,19 +1,7 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import useStyles from './fieldset.styles';
 import ReactPlaceholder from 'react-placeholder';
-
-const useStyles = makeStyles((theme) => ({
-  legend: {
-    fontSize: 18,
-    fontWeight: 500,
-    color: theme.palette.primary.dark,
-  },
-  fieldset: {
-    border: `1px solid ${theme.palette.primary.light}`,
-    margin: '16px 0',
-  }
-}));
 
 const Fieldset = ({ children, completed, legend, rows = 1 }) => {
   const classes = useStyles();
@@ -30,7 +18,7 @@ const Fieldset = ({ children, completed, legend, rows = 1 }) => {
         rows={rows}
         ready={completed}
         lineSpacing={24}
-        style={{ width: '95%', padding: 12 }}
+        className={classes.placeholder}
       >
         {children}
       </ReactPlaceholder>

--- a/frontend/src/components/design-library/atoms/inputs/input-comment/input-comment.styles.ts
+++ b/frontend/src/components/design-library/atoms/inputs/input-comment/input-comment.styles.ts
@@ -1,0 +1,12 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  counter: {
+    fontFamily: 'Roboto',
+    color: '#a9a9a9',
+    marginTop: '10px',
+    textAlign: 'right',
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/inputs/input-comment/input-comment.tsx
+++ b/frontend/src/components/design-library/atoms/inputs/input-comment/input-comment.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { TextareaAutosize, FormControl } from '@material-ui/core';
+import useStyles from './input-comment.styles';
 
 const InputComment = ({ placeholder, onChange }) => {
   const intl = useIntl()
   const [interestedComment, setInterestedComment] = useState('')
   const [charactersCount, setCharactersCount] = useState(0)
+  const classes = useStyles()
 
   const handleInputInterestedCommentChange = (e) => {
     setInterestedComment(e.target.value)
@@ -22,7 +24,7 @@ const InputComment = ({ placeholder, onChange }) => {
         value={interestedComment}
         onChange={handleInputInterestedCommentChange}
       />
-      <small style={{ fontFamily: 'Roboto', color: '#a9a9a9', marginTop: '10px', textAlign: 'right' }}>{charactersCount + '/1000'}</small>
+      <small className={classes.counter}>{charactersCount + '/1000'}</small>
     </FormControl >
   );
 };

--- a/frontend/src/components/design-library/atoms/inputs/price-input/price-input.styles.ts
+++ b/frontend/src/components/design-library/atoms/inputs/price-input/price-input.styles.ts
@@ -1,0 +1,19 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  formPayment: {
+    marginTop: 10,
+    marginBottom: 10,
+  },
+  currencySymbol: {
+    fontSize: 28,
+  },
+  input: {
+    fontSize: 42,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    height: 98,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/inputs/price-input/price-input.tsx
+++ b/frontend/src/components/design-library/atoms/inputs/price-input/price-input.tsx
@@ -3,21 +3,14 @@ import {
   FormControl,
   InputLabel,
   Input,
-  InputAdornment,
-  withStyles 
+  InputAdornment
 } from '@material-ui/core';
-import { Theme, createStyles } from '@material-ui/core/styles';
+import { Theme } from '@material-ui/core/styles';
+import useStyles from './price-input.styles';
 
 
-const styles = (theme: Theme) =>
-  createStyles({
-    formPayment: {
-      marginTop: 10,
-      marginBottom: 10
-    }
-  });
-
-const PriceInput = ({ classes, priceLabel, value, onChange, defaultValue, currency = '$', endAdornment = true }) => {
+const PriceInput = ({ priceLabel, value, onChange, defaultValue, currency = '$', endAdornment = true }) => {
+  const classes = useStyles();
   const [ price, setPrice ] = useState(0)
 
   const handleChange = (event) => {
@@ -44,19 +37,19 @@ const PriceInput = ({ classes, priceLabel, value, onChange, defaultValue, curren
           }
           startAdornment={
             <InputAdornment position='start'>
-              <span style={{ fontSize: 28 }}> {currency} </span>
+              <span className={classes.currencySymbol}> {currency} </span>
             </InputAdornment>
           }
           type='number'
-          inputProps={{ 'min': 0, style: { textAlign: 'right', height: 98 } }}
+          inputProps={{ 'min': 0 }}
           defaultValue={defaultValue}
           value={price}
           onChange={handleChange}
-          style={{ fontSize: 42, fontWeight: 'bold' }}
+          className={classes.input}
         />
       </FormControl>
     </form>
   );
 }
 
-export default withStyles(styles)(PriceInput)
+export default PriceInput

--- a/frontend/src/components/design-library/atoms/loaders/loader/loader.styles.ts
+++ b/frontend/src/components/design-library/atoms/loaders/loader/loader.styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    flexGrow: 1,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
+  },
+  progress: {
+    color: '#009688',
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/loaders/loader/loader.tsx
+++ b/frontend/src/components/design-library/atoms/loaders/loader/loader.tsx
@@ -1,19 +1,7 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
+import useStyles from './loader.styles'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    flexGrow: 1,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center', // fix me : this property did not work
-    height: '100%',
-  },
-  progress: {
-    color: '#009688',
-  }
-}))
 
 function CustomizedProgress() {
   const classes = useStyles()

--- a/frontend/src/components/design-library/atoms/loaders/placeholders/avatar-placeholder.styles.ts
+++ b/frontend/src/components/design-library/atoms/loaders/placeholders/avatar-placeholder.styles.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@material-ui/core/styles'
+
+const useStyles = makeStyles(() => ({
+  placeholder: {
+    width: 40,
+    height: 40,
+    margin: 10,
+  },
+}))
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/loaders/placeholders/avatar-placeholder.tsx
+++ b/frontend/src/components/design-library/atoms/loaders/placeholders/avatar-placeholder.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { RoundShape } from 'react-placeholder/lib/placeholders'
+import useStyles from './avatar-placeholder.styles'
 
-export const AvatarPlaceholder = () => (
-  <div className='avatar-placeholder'>
-    <RoundShape color='#ccc' style={ { width: 40, height: 40, margin: 10 } } />
-  </div>
-)
+export const AvatarPlaceholder = () => {
+  const classes = useStyles()
+  return (
+    <div className='avatar-placeholder'>
+      <RoundShape color='#ccc' className={classes.placeholder} />
+    </div>
+  )
+}

--- a/frontend/src/components/design-library/atoms/status/account-status/account-holder-status/account-holder-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/account-status/account-holder-status/account-holder-status.styles.ts
@@ -1,0 +1,25 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { green, orange } from '@material-ui/core/colors'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    pending: {
+      backgroundColor: orange[500],
+      color: theme.palette.common.white,
+    },
+    active: {
+      backgroundColor: green[500],
+      color: theme.palette.common.white,
+    },
+    inactive: {
+      backgroundColor: theme.palette.grey[400],
+      color: theme.palette.common.white,
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    },
+  })
+)
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/status/account-status/account-holder-status/account-holder-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/account-status/account-holder-status/account-holder-status.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { green, orange } from '@material-ui/core/colors';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import useStyles from './account-holder-status.styles'
 import { 
   CheckCircleOutlineTwoTone as ActiveIcon,
   InfoSharp as InfoIcon,
@@ -10,26 +9,6 @@ import {
 
 import BaseStatus from '../../base-status/base-status';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    pending: {
-      backgroundColor: orange[500],
-      color: theme.palette.common.white,
-    },
-    active: {
-      backgroundColor: green[500],
-      color: theme.palette.common.white,
-    },
-    inactive: {
-      backgroundColor: theme.palette.grey[400],
-      color: theme.palette.common.white,
-    },
-    unknown: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white,
-    },
-  }),
-);
 
 interface AccountHolderStatusProps {
   status: string;

--- a/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.styles.ts
@@ -1,0 +1,25 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
+import { green, orange } from '@material-ui/core/colors'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    pending: {
+      backgroundColor: orange[500],
+      color: theme.palette.common.white,
+    },
+    active: {
+      backgroundColor: green[500],
+      color: theme.palette.common.white,
+    },
+    inactive: {
+      backgroundColor: theme.palette.grey[400],
+      color: theme.palette.common.white,
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    },
+  })
+)
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/account-status/bank-account-status/bank-account-status.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { green, orange } from '@material-ui/core/colors';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import useStyles from './bank-account-status.styles'
 import { 
   CheckCircleOutlineTwoTone as ActiveIcon,
   HelpOutline as QuestionInfoIcon,
@@ -9,26 +8,6 @@ import {
 
 import BaseStatus from '../../base-status/base-status';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    pending: {
-      backgroundColor: orange[500],
-      color: theme.palette.common.white,
-    },
-    active: {
-      backgroundColor: green[500],
-      color: theme.palette.common.white,
-    },
-    inactive: {
-      backgroundColor: theme.palette.grey[400],
-      color: theme.palette.common.white,
-    },
-    unknown: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white,
-    },
-  }),
-);
 
 interface BankAccountStatusProps {
   status: string;

--- a/frontend/src/components/design-library/atoms/status/payment-types-status/invoice-status/invoice-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/payment-types-status/invoice-status/invoice-status.styles.ts
@@ -1,0 +1,45 @@
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles'
+import { cyan, blue, lime, orange } from '@material-ui/core/colors'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    pending: {
+      backgroundColor: orange[900],
+      color: theme.palette.common.white,
+    },
+    draft: {
+      backgroundColor: orange[500],
+      color: theme.palette.common.white,
+    },
+    open: {
+      backgroundColor: orange[300],
+      color: theme.palette.common.white,
+    },
+    paid: {
+      backgroundColor: lime[800],
+      color: theme.palette.common.white,
+    },
+    failed: {
+      backgroundColor: theme.palette.error.main,
+      color: theme.palette.common.white,
+    },
+    uncollectible: {
+      backgroundColor: cyan[500],
+      color: theme.palette.common.white,
+    },
+    void: {
+      backgroundColor: theme.palette.error.main,
+      color: theme.palette.common.white,
+    },
+    refunded: {
+      backgroundColor: blue[500],
+      color: theme.palette.common.white,
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    }
+  })
+)
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/status/payment-types-status/invoice-status/invoice-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/payment-types-status/invoice-status/invoice-status.tsx
@@ -1,49 +1,10 @@
 import React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import { createStyles, Theme } from '@material-ui/core/styles';
 import { cyan, blue, lime, orange } from '@material-ui/core/colors';
 import Chip from '@material-ui/core/Chip';
 import { status } from '../../../../../../consts'
+import useStyles from './invoice-status.styles'
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    pending: {
-      backgroundColor: orange[900],
-      color: theme.palette.common.white,
-    },
-    draft: {
-      backgroundColor: orange[500],
-      color: theme.palette.common.white,
-    },
-    open: {
-      backgroundColor: orange[300],
-      color: theme.palette.common.white,
-    },
-    paid: {
-      backgroundColor: lime[800],
-      color: theme.palette.common.white,
-    },
-    failed: {
-      backgroundColor: theme.palette.error.main,
-      color: theme.palette.common.white,
-    },
-    uncollectible: {
-      backgroundColor: cyan[500],
-      color: theme.palette.common.white,
-    },
-    void: {
-      backgroundColor: theme.palette.error.main,
-      color: theme.palette.common.white,
-    },
-    refunded: {
-      backgroundColor: blue[500],
-      color: theme.palette.common.white,
-    },
-    unknown: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white
-    }
-  }),
-);
 
 type statusProps = {
   invoiceStatus: string;

--- a/frontend/src/components/design-library/atoms/status/payment-types-status/payment-status/payment-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/payment-types-status/payment-status/payment-status.styles.ts
@@ -1,0 +1,37 @@
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles'
+import { orange, green, yellow } from '@material-ui/core/colors'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    open: {
+      backgroundColor: yellow[700],
+      color: theme.palette.common.white,
+    },
+    pending: {
+      backgroundColor: orange[500],
+      color: theme.palette.common.white,
+    },
+    succeeded: {
+      backgroundColor: green[500],
+      color: theme.palette.common.white,
+    },
+    failed: {
+      backgroundColor: theme.palette.error.main,
+      color: theme.palette.common.white,
+    },
+    expired: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    },
+    canceled: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    },
+    unknown: {
+      backgroundColor: theme.palette.grey[500],
+      color: theme.palette.common.white,
+    }
+  })
+)
+
+export default useStyles

--- a/frontend/src/components/design-library/atoms/status/payment-types-status/payment-status/payment-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/payment-types-status/payment-status/payment-status.tsx
@@ -1,41 +1,9 @@
 import React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import { orange, green, yellow } from '@material-ui/core/colors';
 import Chip from '@material-ui/core/Chip';
 import { status } from '../../../../../../consts'
+import useStyles from './payment-status.styles'
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    open: {
-      backgroundColor: yellow[700],
-      color: theme.palette.common.white,
-    },
-    pending: {
-      backgroundColor: orange[500],
-      color: theme.palette.common.white,
-    },
-    succeeded: {
-      backgroundColor: green[500],
-      color: theme.palette.common.white,
-    },
-    failed: {
-      backgroundColor: theme.palette.error.main,
-      color: theme.palette.common.white,
-    },
-    expired: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white,
-    },
-    canceled: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white
-    },
-    unknown: {
-      backgroundColor: theme.palette.grey[500],
-      color: theme.palette.common.white
-    }
-  }),
-);
 
 type statusProps = {
   orderStatus: string;


### PR DESCRIPTION
## Summary
- extract makeStyles usage from many atom components in `frontend/src/components/design-library/atoms`
- create companion `*.styles.ts` files for each component
- adjust imports and replace inline styles with class usage

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400479dad8832bbf9aa21471739b65