### PR TITLE
Fix typos in user-facing messages 

### DIFF
--- a/frontend/src/components/areas/private/features/dashboard/profile-options.tsx
+++ b/frontend/src/components/areas/private/features/dashboard/profile-options.tsx
@@ -255,7 +255,7 @@ const ProfileOptions = ({ user }) => {
               <Typography variant="body2">
                 <FormattedMessage
                   id="account.profile.roles.description"
-                  defaultMessage="Set your roles to define your capatibilities on Gitpay"
+                  defaultMessage="Set your roles to define your capabilities on Gitpay"
                 />
               </Typography>
             </CardContent>

--- a/frontend/src/components/areas/public/features/task/task-report.js
+++ b/frontend/src/components/areas/public/features/task/task-report.js
@@ -99,7 +99,7 @@ class TaskReport extends Component {
           <DialogContent>
             <Typography variant='subtitle1' gutterBottom style={ { color: 'grey', fontWeight: 'bold', marginBottom: 20 } }>
               <FormattedMessage id='task.report.subtitle' defaultMessage='If you think this issue is invalid, is just for test purposes,
-                or has some error or even inapropriate content, please let us know and we will take action' />
+                or has some error or even inappropriate content, please let us know and we will take action' />
             </Typography>
             <form onChange={ this.onChangeReason } type='POST' style={ { marginTop: '20px 0px 10px', color: 'grey' } }>
               <FormControl fullWidth >


### PR DESCRIPTION


Description:
This pull request corrects minor typos in user-facing messages:
- In the profile options, "capabilities" is now spelled correctly.
- In the task report dialog, "inappropriate" is now spelled correctly.
No functional changes were made; this PR only improves the accuracy of displayed text.
