### PR TITLE
Move component tests next to sources

### DIFF
--- a/frontend/src/components/areas/private/components/session/__tests__/login-form.test.jsx
+++ b/frontend/src/components/areas/private/components/session/__tests__/login-form.test.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom';
-import LoginForm from '../../src/components/areas/private/components/session/login-form';
+import LoginForm from '../login-form';
 
 // Instantiate router context
 const router = {

--- a/frontend/src/components/areas/private/features/payments/legacy/checkout/__tests__/checkout.test.js
+++ b/frontend/src/components/areas/private/features/payments/legacy/checkout/__tests__/checkout.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react'
-import { CheckoutFormPure } from '../../src/components/areas/private/features/payments/legacy/checkout/checkout-form'
+import { CheckoutFormPure } from '../checkout-form'
 import { mount } from 'enzyme'
 
 /*

--- a/frontend/src/components/areas/public/features/task/__tests__/messageAuthor.test.js
+++ b/frontend/src/components/areas/public/features/task/__tests__/messageAuthor.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react'
-import MessageAuthor from '../../src/components/areas/public/features/task/task-message-author'
+import MessageAuthor from '../task-message-author'
 import { mount } from 'enzyme'
 
 xdescribe('components', () => {

--- a/frontend/src/components/areas/public/features/task/components/__tests__/task-solution-drawer.test.js
+++ b/frontend/src/components/areas/public/features/task/components/__tests__/task-solution-drawer.test.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import TaskSolutionDrawer from '../../../src/components/areas/public/features/task/components/send-solution-drawer';
+import TaskSolutionDrawer from '../send-solution-drawer';
 import { BrowserRouter } from 'react-router-dom';
 import { debug } from 'jest-preview';
 

--- a/frontend/src/components/design-library/molecules/cards/team-card/__tests__/cardTeam.test.js
+++ b/frontend/src/components/design-library/molecules/cards/team-card/__tests__/cardTeam.test.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react'
-import TeamCard from '../../src/components/design-library/molecules/cards/team-card/TeamCard'
+import TeamCard from '../TeamCard'
 import { mount } from 'enzyme'
 
 xdescribe('components', () => {


### PR DESCRIPTION
## Summary
- relocate frontend component tests next to their respective components
- update imports to match new locations

## Testing
- `npm test` *(fails: OAuth2Strategy requires a clientID option)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527d504cb0832b90c96ac96f3366a5