### PR TITLE
feat: add filters to public explore page

### DIFF
--- a/frontend/src/components/areas/public/features/task/language-filter.stories.tsx
+++ b/frontend/src/components/areas/public/features/task/language-filter.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import LanguageFilter from './language-filter';
+
+export default {
+  title: 'Features/Task/LanguageFilter',
+  component: LanguageFilter,
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+const Template = (args) => <LanguageFilter {...args} />;
+
+const mockLanguages = {
+  data: [
+    { id: 1, name: 'JavaScript' },
+    { id: 2, name: 'TypeScript' },
+    { id: 3, name: 'Python' },
+    { id: 4, name: 'Java' },
+    { id: 5, name: 'React' },
+    { id: 6, name: 'Node.js' },
+  ]
+};
+
+const mockListLanguages = () => {
+  console.log('List languages called');
+};
+
+const mockListTasks = (filters) => {
+  console.log('List tasks called with filters:', filters);
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  languages: mockLanguages,
+  listLanguages: mockListLanguages,
+  listTasks: mockListTasks,
+};
+
+export const EmptyLanguages = Template.bind({});
+EmptyLanguages.args = {
+  languages: { data: [] },
+  listLanguages: mockListLanguages,
+  listTasks: mockListTasks,
+};
+
+export const ManyLanguages = Template.bind({});
+ManyLanguages.args = {
+  languages: {
+    data: [
+      { id: 1, name: 'JavaScript' },
+      { id: 2, name: 'TypeScript' },
+      { id: 3, name: 'Python' },
+      { id: 4, name: 'Java' },
+      { id: 5, name: 'React' },
+      { id: 6, name: 'Node.js' },
+      { id: 7, name: 'Vue.js' },
+      { id: 8, name: 'Angular' },
+      { id: 9, name: 'C++' },
+      { id: 10, name: 'Go' },
+      { id: 11, name: 'Rust' },
+      { id: 12, name: 'PHP' },
+    ]
+  },
+  listLanguages: mockListLanguages,
+  listTasks: mockListTasks,
+}; 

--- a/frontend/src/components/areas/public/features/task/task-explorer.js
+++ b/frontend/src/components/areas/public/features/task/task-explorer.js
@@ -19,6 +19,7 @@ import { Page, PageContent } from 'app/styleguide/components/Page'
 import TaskListContainer from '../../../../../containers/task-list'
 import ProjectListContainer from '../../../../../containers/project-list'
 import OrganizationListContainer from '../../../../../containers/organization-list'
+import TaskFiltersContainer from '../../../../../containers/task-filter'
 
 const styles = theme => ({
   root: {
@@ -199,9 +200,15 @@ const TaskExplorer = (props) => {
         <Container fixed maxWidth='lg'>
           <Grid container className={ classes.root }>
             <Grid item xs={ 12 } md={ 12 }>
-              { state.value === 0 &&
-                <TaskListContainer />
-              }
+              { state.value === 0 && (
+                <div>
+                  <TaskFiltersContainer
+                    filterTasks={ props.filterTasks }
+                    baseUrl="/tasks/"
+                  />
+                  <TaskListContainer />
+                </div>
+              )}
               { state.value === 1 &&
                 <ProjectListContainer />
               }

--- a/frontend/src/components/areas/public/features/task/task-filter-labels.stories.tsx
+++ b/frontend/src/components/areas/public/features/task/task-filter-labels.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import TaskFilterLabels from './task-filter-labels';
+
+export default {
+  title: 'Features/Task/TaskFilterLabels',
+  component: TaskFilterLabels,
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+
+const Template = (args) => <TaskFilterLabels {...args} />;
+
+const mockLabels = {
+  data: [
+    { id: 1, name: 'bug' },
+    { id: 2, name: 'enhancement' },
+    { id: 3, name: 'documentation' },
+    { id: 4, name: 'good first issue' },
+    { id: 5, name: 'help wanted' },
+  ]
+};
+
+const mockListLabels = () => {
+  console.log('List labels called');
+};
+
+const mockListTasks = (filters) => {
+  console.log('List tasks called with filters:', filters);
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  labels: mockLabels,
+  listLabels: mockListLabels,
+  listTasks: mockListTasks,
+};
+
+export const EmptyLabels = Template.bind({});
+EmptyLabels.args = {
+  labels: { data: [] },
+  listLabels: mockListLabels,
+  listTasks: mockListTasks,
+};
+
+export const ManyLabels = Template.bind({});
+ManyLabels.args = {
+  labels: {
+    data: [
+      { id: 1, name: 'bug' },
+      { id: 2, name: 'enhancement' },
+      { id: 3, name: 'documentation' },
+      { id: 4, name: 'good first issue' },
+      { id: 5, name: 'help wanted' },
+      { id: 6, name: 'frontend' },
+      { id: 7, name: 'backend' },
+      { id: 8, name: 'ui/ux' },
+      { id: 9, name: 'performance' },
+      { id: 10, name: 'testing' },
+    ]
+  },
+  listLabels: mockListLabels,
+  listTasks: mockListTasks,
+}; 

--- a/frontend/src/components/areas/public/features/task/task-filters.stories.tsx
+++ b/frontend/src/components/areas/public/features/task/task-filters.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TaskFilters from './task-filters';
+
+export default {
+  title: 'Features/Task/TaskFilters',
+  component: TaskFilters,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+const Template = (args) => <TaskFilters {...args} />;
+
+const mockTasks = [
+  { id: 1, value: '100', status: 'open', title: 'Task with bounty' },
+  { id: 2, value: '0', status: 'open', title: 'Task without bounty' },
+  { id: 3, value: '50', status: 'open', title: 'Another task with bounty' },
+  { id: 4, value: '0', status: 'open', title: 'Another task without bounty' },
+];
+
+const mockFilterTasks = (key, value) => {
+  console.log('Filter called with:', key, value);
+  return Promise.resolve();
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  tasks: mockTasks,
+  filteredTasks: mockTasks,
+  filterTasks: mockFilterTasks,
+  baseUrl: '/tasks/',
+};
+
+export const WithBounties = Template.bind({});
+WithBounties.args = {
+  tasks: mockTasks,
+  filteredTasks: mockTasks.filter(task => parseFloat(task.value) > 0),
+  filterTasks: mockFilterTasks,
+  baseUrl: '/tasks/',
+};
+
+export const WithoutBounties = Template.bind({});
+WithoutBounties.args = {
+  tasks: mockTasks,
+  filteredTasks: mockTasks.filter(task => parseFloat(task.value) === 0),
+  filterTasks: mockFilterTasks,
+  baseUrl: '/tasks/',
+};
+
+export const ProfileExplore = Template.bind({});
+ProfileExplore.args = {
+  tasks: mockTasks,
+  filteredTasks: mockTasks,
+  filterTasks: mockFilterTasks,
+  baseUrl: '/profile/explore/',
+}; 

--- a/frontend/src/containers/task-explorer.js
+++ b/frontend/src/containers/task-explorer.js
@@ -1,12 +1,19 @@
 /* eslint-disable no-console */
 import { connect } from 'react-redux'
 import TaskExplorer from '../components/areas/public/features/task/task-explorer'
-import { listTasks } from '../actions/taskActions'
+import { listTasks, filterTasks } from '../actions/taskActions'
+import { getFilteredTasks } from '../selectors/tasks'
+
+const mapStateToProps = (state) => ({
+  tasks: state.tasks.data,
+  filteredTasks: getFilteredTasks(state)
+})
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    listTasks: ({ status }) => dispatch(listTasks({ status }))
+    listTasks: ({ status }) => dispatch(listTasks({ status })),
+    filterTasks: (tasks, key, value, additional) => dispatch(filterTasks(tasks, key, value, additional))
   }
 }
 
-export default connect(undefined, mapDispatchToProps)(TaskExplorer)
+export default connect(mapStateToProps, mapDispatchToProps)(TaskExplorer)


### PR DESCRIPTION
# 🔍 Add Filters to Public Explore Page

Closes #1202 

## ✏️ Summary

Added the same filters available on the logged user explore page (`/profile/explore`) to the public explore page (`/tasks/open`), providing consistent filtering functionality across both interfaces.

## 📋 Description

This PR implements the requested feature to display filters on the public explore page that were previously only available to logged-in users. The implementation ensures both pages now have identical filtering capabilities.

### 🔧 Changes Made:

1. **Enhanced TaskExplorer Container** (`frontend/src/containers/task-explorer.js`)
   - Added `filterTasks` action import and dispatch
   - Added tasks data access via `mapStateToProps`
   - Connected filtered tasks selector

2. **Updated TaskExplorer Component** (`frontend/src/components/areas/public/features/task/task-explorer.js`)
   - Imported `TaskFiltersContainer` 
   - Integrated filters when showing Issues tab (state.value === 0)
   - Set correct baseUrl for public pages (`"/tasks/"`)

3. **Created Comprehensive Storybook Stories**
   - `TaskFilters` main component stories
   - `TaskFilterLabels` component stories  
   - `LanguageFilter` component stories

### 🎯 Available Filters Now on Public Page:

- **Status Filter Dropdown**: All issues / With bounties / Without bounties
- **Labels Filter**: Multi-select with checkboxes (bug, enhancement, documentation, etc.)
- **Language Filter**: Multi-select with checkboxes (JavaScript, Python, React, etc.)

## 🧪 Testing

### Manual Testing:
1. Navigate to `localhost:8082/#/tasks/open`
2. Verify filters appear above the task list
3. Test each filter functionality:
   - Status filter dropdown changes task list
   - Labels multi-select filters by labels
   - Language multi-select filters by programming languages

### Storybook Testing:
1. Run `npm run storybook`
2. Check stories under:
   - `Features/Task/TaskFilters`
   - `Features/Task/TaskFilterLabels`
   - `Features/Task/LanguageFilter`

## ✅ Requirements Met

- [x] Filters from logged page are now on public page
- [x] All components use base Material-UI Select component
- [x] Complete Storybook documentation
- [x] Maintains existing functionality
- [x] Same filtering experience across both pages

## 🧰 Stack Used

- React
- Material-UI 
- Storybook
- Redux (for state management)

**Note**: This implementation ensures feature parity between public and logged user experiences while maintaining all existing functionality.