### PR TITLE
Feature/collapsed UI menu

### DIFF
--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.tsx
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import logo from 'images/gitpay-logo.png'
-import responsiveLogo from 'images/logo-symbol.png'
 import {
   IconHamburger,
   LeftSide,


### PR DESCRIPTION
> Closes #1197

## Description

- Implemented a **collapsible SideMenu** with `collapsed` state using `useState`.
- Replaced the mobile-only hamburger menu with a universal **collapse/expand toggle** using  
  `ChevronLeftIcon` and `ChevronRightIcon` from `@mui/icons-material`.
- When collapsed:
  - Only icons are shown in the menu.
  - Tooltips appear on hover for accessibility.
  - Compact logo (`responsiveLogo`) is displayed.
- When expanded:
  - Both icons and labels are visible.
  - Full-size logo (`logo`) is shown.
- Menu layout is responsive using `useMediaQuery`.

## Purpose

Enhances the UX by allowing users to collapse the sidebar for more content space. Makes the layout responsive and consistent across screen sizes.

## Solution

- Introduced `collapsed` state in `SideMenu.tsx`.
- Added a toggle button using:
  - `<ChevronLeftIcon />` when expanded
  - `<ChevronRightIcon />` when collapsed
- Conditionally rendered logo, text, and tooltips based on `collapsed` and `isMobile`.
- Updated `makeStyles` to adapt styles dynamically.
- Ensured that only icons show on collapse with proper spacing and alignment.

## Checklist

- [x] Code tested and functions as intended
- [x] Collapse/expand toggle works with Chevron icons
- [x] Tooltip shows in collapsed mode
- [x] Logo swaps correctly based on state
- [x] Responsive behavior verified
- [x] Follows code style and best practices
- [x] No merge conflicts
- [x] Reviewed by another team member

## Related Issues

- Fixes #1197

