### PR TITLE
supporting mobile menu for private pages

### DIFF
--- a/frontend/src/components/areas/private/components/profile-sidebar.tsx
+++ b/frontend/src/components/areas/private/components/profile-sidebar.tsx
@@ -42,7 +42,7 @@ const ProfileSidebar = ({
   }, [history.location.pathname])
 
   return (
-    <Grid item xs={ 12 } md={ 2 } spacing={ 0 } className={ classes.sidePaper }>
+    <Grid item xs={ 12 } md={ 1 } spacing={ 0 } className={ classes.sidePaper }>
       <SideMenu
         completed={ user.completed }
         menuItems={

--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu-items.tsx
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu-items.tsx
@@ -1,0 +1,66 @@
+
+import { MenuList, Typography, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import React from 'react'
+
+const useStyles = makeStyles((theme) => ({
+  menuItem: {
+    marginTop: 10,
+    marginBottom: 10
+  },
+  primary: {
+    color: theme.palette.primary.contrastText,
+    fontSize: '11px !important',
+    fontWeight: 500
+  },
+  icon: {
+    marginRight: 5,
+    color: theme.palette.primary.contrastText
+  },
+  category: {
+    color: "rgba(255, 255, 255, 0.5)",
+    fontSize: "0.58rem",
+    textTransform: "uppercase",
+    fontWeight: 600,
+    marginBottom: 16,
+    paddingLeft: 16
+  }
+}))
+
+const SideMenuItems = ({
+  menuItems
+}) => {
+  const classes = useStyles()
+  return (
+    <MenuList>
+      {menuItems.map((section, sectionIndex) => (
+        <div key={`section-${sectionIndex}`}>
+          {section.category && (
+            <Typography
+              variant="caption"
+              className={classes.category}
+              style={{ marginTop: sectionIndex === 0 ? 0 : 16 }}
+            >
+              {section.category}
+            </Typography>
+          )}
+          {section.items.map((item, index) => (
+            item.include && (
+              <MenuItem
+                key={`item-${sectionIndex}-${index}`}
+                onClick={item.onClick}
+                className={classes.menuItem}
+                selected={item.selected}
+              >
+                <ListItemIcon className={classes.icon}><>{item.icon}</></ListItemIcon>
+                <ListItemText classes={{ primary: classes.primary }} primary={item.label} />
+              </MenuItem>
+            )
+          ))}
+        </div>
+      ))}
+    </MenuList>
+  )
+}
+
+export default SideMenuItems

--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.js
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.js
@@ -40,7 +40,6 @@ export const IconHamburger = styled.span`
   width: 25px;
   height: 3px;
   position: relative;
-  top: 5px;
 
   transition-delay: 200ms;
   transform-origin: 50% 50%;
@@ -85,9 +84,8 @@ export const IconHamburger = styled.span`
 `
 
 export const LeftSide = styled(Side)`
-  display: flex;
-  align-items: space-between;
-  justify-content: space-between;
+  display: block;
+  
   z-index: 1300;
   padding: 0;
   width: 100%;
@@ -106,15 +104,15 @@ export const LeftSide = styled(Side)`
     box-sizing: border-box;
   `}
 
-  @media (min-width: 37.5em) {
+  @media (max-width: 37.5em) {
     align-items: flex-start;
     justify-content: flex-start;
   }
 `
 
 export const RightSide = styled(Side)`
-  justify-content: flex-start;
-  align-items: flex-start;
+  display: block;
+  width: 100%;
 
 @media (max-width: 37.5em) {
     display: flex;
@@ -123,7 +121,7 @@ export const RightSide = styled(Side)`
     top: 0;
     right: 0;
     background-color: #2c5c46;
-    height: 80vh;
+    height: 100vh;
     width: 100vw;
     justify-content: center;
     align-items: center;

--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.js
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.js
@@ -1,0 +1,234 @@
+import styled, { css } from 'styled-components'
+import {
+  Button,
+  Avatar
+} from '@material-ui/core'
+
+import media from '../../../../../styleguide/media'
+
+export const Bar = styled.div`
+  box-sizing: border-box;
+  padding: 10px 20px;
+  background-color: black;
+  margin: 0;
+  position: relative;
+
+  ${media.phone`
+    padding: 10px 15px;
+  `}
+`
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+export const Side = styled.div`
+  display: flex;
+`
+export const MenuMobile = styled(Button)`
+    margin: 10px 0;
+    @media (min-width: 37.5em) {
+      display: none;
+      visibility: hidden;
+  }
+`
+
+export const IconHamburger = styled.span`
+  background-color: #009688;
+  width: 25px;
+  height: 3px;
+  position: relative;
+  top: 5px;
+
+  transition-delay: 200ms;
+  transform-origin: 50% 50%;
+
+  ${({ isActive }) => isActive && css`
+    background-color: transparent;
+  `}
+
+  &::after,
+  &::before {
+    content: '';
+    background-color: #009688;
+    width: 25px;
+    height: 3px;
+    position: absolute;
+    left: 0;
+    transition: all ease 400ms;
+  }
+
+  &::after{
+    top: -6px;
+
+    ${({ isActive }) => isActive && css`
+      top: 0;
+      background-color: #f2f2f2;
+      transform: rotate(135deg)
+    `}
+  }
+
+  &::before{
+    bottom: -6px;
+
+    ${({ isActive }) => isActive && css`
+      bottom: 0;
+      background-color: #f2f2f2;
+      transform: rotate(-135deg)
+    `}
+  }
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+export const LeftSide = styled(Side)`
+  display: flex;
+  align-items: space-between;
+  justify-content: space-between;
+  z-index: 1300;
+  padding: 0;
+  width: 100%;
+
+  a {
+    margin-bottom: 0 !important;
+  }
+
+  ${({ isActive }) => isActive && css`
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: #2c5c46;
+    padding: 10px 20px;
+    box-sizing: border-box;
+  `}
+
+  @media (min-width: 37.5em) {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+`
+
+export const RightSide = styled(Side)`
+  justify-content: flex-start;
+  align-items: flex-start;
+
+@media (max-width: 37.5em) {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    right: 0;
+    background-color: #2c5c46;
+    height: 80vh;
+    width: 100vw;
+    justify-content: center;
+    align-items: center;
+    transform: translateY(-100%);
+    transition: all ease-in-out 400ms;
+    z-index: 1200;
+
+  ${({ isActive }) => isActive && css`
+      transform: translateY(0);
+      overflow: hidden;
+    `}
+
+    ${({ isActive }) => {
+    if (isActive) {
+      // document.body.style.overflowY = 'hidden'
+    }
+    else {
+      // document.body.style.overflowY = 'auto'
+    }
+  }}
+  }
+`
+
+export const Logo = styled.img`
+  width: 96px;
+
+  ${media.phone`width: 100px !important;`}
+`
+
+export const StyledButton = styled(Button)`
+  min-width: 20px !important;
+  font-size: 12px;
+  cursor: pointer;
+  margin-left: 10px !important;
+`
+
+export const LogoButton = styled(StyledButton)`
+  ${media.phone`
+    padding: 0px !important;
+  `}
+`
+
+export const LinkButton = styled(StyledButton)`
+  color: #fff !important;
+`
+
+export const StyledLanguageButton = styled(StyledButton)`
+  ${media.phone`
+    display: none !important;
+  `}
+`
+
+export const StyledSlackButton = styled(StyledButton)`
+  ${media.phone`
+    display: none !important;
+  `}
+`
+
+export const LabelButton = styled.span`
+
+  ${props => props.right
+    ? css`margin-left: 10px;`
+    : css`margin-right: 10px;`}
+
+  @media (min-width: 37.5em) {
+    display: none;
+    margin-right: 0;
+  }
+
+  @media (min-width: 64em) {
+    display: block;
+    margin-right: 10px;
+  }
+`
+
+export const StyledAvatar = styled(Avatar)`
+  margin-left: 20px;
+  cursor: pointer;
+
+
+  ${media.phone`margin-left: 15px;`}
+`
+
+export const StyledAvatarIconOnly = styled(Avatar)`
+  margin-left: 20px;
+  cursor: pointer;
+  align-items: center;
+  ${media.phone`margin-left: 15px;`}
+
+  @media(max-width: 37.5em){
+    margin-bottom: 20px !important;
+  }
+`
+
+export const OnlyDesktop = styled.div`
+  @media(max-width: 37.5em){
+    display: none;
+  }
+`
+
+export const OnlyMobile = styled.div`
+  display: none;
+  justify-ontent: space-around;
+  flex-direction: column;
+  @media (max-width: 37.5em) {
+    display: flex;
+  }
+`

--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.tsx
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.tsx
@@ -3,11 +3,19 @@ import { makeStyles } from '@material-ui/core/styles'
 import { MenuList, MenuItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core'
 import logo from 'images/gitpay-logo.png'
 import {
+  IconHamburger,
+  LeftSide,
   Logo,
+  MenuMobile,
+  OnlyDesktop,
+  OnlyMobile,
+  RightSide,
   StyledButton
-} from '../../../organisms/layouts/topbar/TopbarStyles'
+} from './side-menu.styled.div'
 import ReactPlaceholder from 'react-placeholder'
 import SideMenuPlaceholder from './side-menu.placeholder'
+import SideMenuItems from './side-menu-items'
+import { red } from '@material-ui/core/colors'
 
 const useStyles = makeStyles((theme) => ({
   sidePaper: {
@@ -16,7 +24,22 @@ const useStyles = makeStyles((theme) => ({
   },
   row: {
     display: 'flex',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+    }
+  },
+  mainHeaderWrapper: { 
+    display: 'flex',
+    justifyContent: 'center',
+    padding: 20,
+    paddingBottom: 0,
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: 10,
+    }
   },
   menuItem: {
     marginTop: 10,
@@ -35,7 +58,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.primary.contrastText,
     fontSize: '11px !important',
     fontWeight: 500
-    
+
   },
   icon: {
     marginRight: 5,
@@ -105,7 +128,11 @@ const useStyles = makeStyles((theme) => ({
       height: '25px',
       width: '25px',
       marginLeft: 15
+    },
+    [theme.breakpoints.down('sm')]: {
+      //border: '1px solid red'
     }
+    
   }
 }))
 
@@ -132,65 +159,55 @@ export const SideMenu: React.FC<SideMenuProps> = ({
 }) => {
   const classes = useStyles()
   const [selected, setSelected] = useState(0)
+  const [isActive, setIsActive] = useState(false)
+
+  const handleClickMenuMobile = () => {
+    setIsActive(!isActive)
+  }
+
 
   return (
     <div className={classes.sidePaper}>
       <div>
         <div className={classes.profile}>
-          <div style={{ display: 'flex', justifyContent: 'center', padding: 20, paddingBottom: 0 }}>
-            <StyledButton href="/">
-              <Logo src={logo} />
-            </StyledButton>
-          </div>
-          <div className={classes.row}>
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              flex: 1,
-              padding: '5px 20px'
-            }}>
-              <ReactPlaceholder
-                ready={completed}
-                customPlaceholder={<SideMenuPlaceholder />}
+          <LeftSide isActive={isActive}>
+            <div className={classes.mainHeaderWrapper}>
+              <StyledButton href="/">
+                <Logo src={logo} />
+              </StyledButton>
+              <MenuMobile
+                onClick={handleClickMenuMobile}
+                variant="text"
+                size="small"
               >
-              <MenuList>
-                {menuItems.map((section, sectionIndex) => (
-                  <div key={`section-${sectionIndex}`}>
-                    {section.category && (
-                    <Typography
-                      variant="caption"
-                      style={{
-                        color: "rgba(255, 255, 255, 0.5)",
-                        fontSize: "0.58rem",
-                        textTransform: "uppercase",
-                        fontWeight: 600,
-                        marginTop: sectionIndex === 0 ? 0 : 16,
-                        marginBottom: 16,
-                        paddingLeft: 16
-                      }}
-                    >
-                      {section.category}
-                    </Typography>
-                    )}
-                    {section.items.map((item, index) => (
-                      item.include && (
-                        <MenuItem
-                          key={`item-${sectionIndex}-${index}`}
-                          onClick={item.onClick}
-                          className={classes.menuItem}
-                          selected={item.selected}
-                        >
-                          <ListItemIcon className={classes.icon}><>{item.icon}</></ListItemIcon>
-                          <ListItemText classes={{ primary: classes.primary }} primary={item.label} />
-                        </MenuItem>
-                      )
-                    ))}
-                  </div>
-                ))}
-              </MenuList>
-              </ReactPlaceholder>
+                <IconHamburger isActive={isActive} />
+              </MenuMobile>
             </div>
-          </div>
+          </LeftSide>
+          <RightSide isActive={isActive}>
+            <div className={classes.row}>
+              <div style={{
+                display: 'flex',
+                flexDirection: 'column',
+                flex: 1,
+                padding: '5px 20px'
+              }}>
+                <ReactPlaceholder
+                  ready={completed}
+                  customPlaceholder={<SideMenuPlaceholder />}
+                >
+                  <OnlyDesktop>
+                    <SideMenuItems menuItems={menuItems} />
+                  </OnlyDesktop>
+
+                  <OnlyMobile>
+                    <SideMenuItems menuItems={menuItems} />
+                  </OnlyMobile>
+
+                </ReactPlaceholder>
+              </div>
+
+            </div></RightSide>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the side menu component in the frontend. The changes focus on modularizing the code, improving the responsiveness of the side menu, and enhancing the user experience with mobile-friendly features. The most important changes are grouped into modularization, styling improvements, and mobile responsiveness.

### Modularization:
* Extracted menu item rendering logic into a new `SideMenuItems` component for better code organization and reusability (`side-menu-items.tsx`).
* Moved styles from `TopbarStyles` to a new `side-menu.styled.div` file, enabling the use of `styled-components` for cleaner and more maintainable styling.

### Styling Improvements:
* Added new `useStyles` definitions to improve layout and alignment, including responsive adjustments for smaller screens (`side-menu.tsx`). [[1]](diffhunk://#diff-904ff0e4c6ffeb1111b16801c0f8d257f9ee8695017c80dbb1d268a69f7b9a88L19-R42) [[2]](diffhunk://#diff-904ff0e4c6ffeb1111b16801c0f8d257f9ee8695017c80dbb1d268a69f7b9a88R131-R135)

### Mobile Responsiveness:
* Introduced a mobile menu toggle (`MenuMobile`) with a hamburger icon (`IconHamburger`) to enhance usability on smaller screens.
* Updated the side menu to use `OnlyDesktop` and `OnlyMobile` wrappers for rendering menu items conditionally based on the viewport size.