### PR TITLE
Custom amount for Payment Requests

### DIFF
--- a/migration/migrations/20250722211021-add-custom-amount-to-payment-request.js
+++ b/migration/migrations/20250722211021-add-custom-amount-to-payment-request.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.addColumn('PaymentRequests', 'custom_amount', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.removeColumn('PaymentRequests', 'custom_amount');
+  }
+};


### PR DESCRIPTION
This pull request introduces a database migration to add a new column to the `PaymentRequests` table. The change allows for the inclusion of a `custom_amount` field, which is a boolean indicating whether a custom amount is specified.

### Database migration:

* [`migration/migrations/20250722211021-add-custom-amount-to-payment-request.js`](diffhunk://#diff-7fbc2ce79ba8b81876e137728917717ddb67f84dc2bcd6b0e361635c61016bc9R1-R27): Added a new column `custom_amount` to the `PaymentRequests` table. The column is of type `BOOLEAN` and has a default value of `false`. The migration also includes a `down` method to remove the column if the migration is rolled back.