### PR TITLE
assigning current user session for all task solution endpoints

### DIFF
--- a/frontend/src/actions/taskSolutionActions.js
+++ b/frontend/src/actions/taskSolutionActions.js
@@ -42,11 +42,11 @@ const getTaskSolutionError = error => {
   return { type: GET_TASK_SOLUTION_ERROR, completed: true, error: error }
 }
 
-const getTaskSolution = (userId, taskId) => {
+const getTaskSolution = (taskId) => {
   validToken()
   return dispatch => {
     dispatch(getTaskSolutionRequested())
-    return axios.get(`${api.API_URL}/tasksolutions`, { params: { userId: userId, taskId: taskId } }).then(response => {
+    return axios.get(`${api.API_URL}/tasksolutions`, { params: { taskId: taskId } }).then(response => {
       return dispatch(getTaskSolutionSuccess(response.data))
     }).catch(error => {
       if (error) {
@@ -77,12 +77,12 @@ const createTaskSolutionError = error => {
   return { type: CREATE_TASK_SOLUTION_ERROR, completed: true, error: error }
 }
 
-const fetchPullRequestData = (owner, repositoryName, pullRequestId, userId, taskId) => {
+const fetchPullRequestData = (owner, repositoryName, pullRequestId, taskId) => {
   validToken()
   return dispatch => {
     dispatch(fetchPullRequestDataRequested())
     return axios.get(`${api.API_URL}/tasksolutions/fetch`, {
-      params: { owner: owner, repositoryName: repositoryName, pullRequestId: pullRequestId, userId: userId, taskId: taskId }
+      params: { owner: owner, repositoryName: repositoryName, pullRequestId: pullRequestId, taskId: taskId }
     }).then(response => {
       return dispatch(fetchPullRequestDataSuccess(response.data))
     }).catch(error => {
@@ -138,11 +138,11 @@ const updateTaskSolutionError = error => {
   return { type: UPDATE_TASK_SOLUTION_ERROR, completed: true, error: error }
 }
 
-const updateTaskSolution = ({ taskSolutionId, pullRequestURL, userId, taskId }) => {
+const updateTaskSolution = ({ taskSolutionId, pullRequestURL, taskId }) => {
   validToken()
   return dispatch => {
     dispatch(updateTaskSolutionRequested())
-    return axios.patch(`${api.API_URL}/tasksolutions/${taskSolutionId}`, { pullRequestURL: pullRequestURL, userId: userId, taskId: taskId }).then(response => {
+    return axios.patch(`${api.API_URL}/tasksolutions/${taskSolutionId}`, { pullRequestURL: pullRequestURL, taskId: taskId }).then(response => {
       dispatch(addNotification('issue.solution.dialog.update.success'))
       dispatch(fetchTask(taskId))
       return dispatch(updateTaskSolutionSuccess(response.data))

--- a/frontend/src/components/areas/public/features/task/components/send-solution-drawer.tsx
+++ b/frontend/src/components/areas/public/features/task/components/send-solution-drawer.tsx
@@ -19,7 +19,7 @@ const SendSolutionDrawer = props => {
   const { taskSolution, pullRequestData, task, user, fetchAccount, account, history } = props
 
   useEffect(() => {
-    user.id && task.data.id && props.getTaskSolution(user.id, task.data.id)
+    user.id && task.data.id && props.getTaskSolution(task.data.id)
   }, [user, task])
 
   useEffect(() => {
@@ -31,7 +31,7 @@ const SendSolutionDrawer = props => {
       clearTimeout(timer)
       setTimer(setTimeout(() => {
         const urlSplitted = pullRequestURL.split('/')
-        props.fetchPullRequestData(urlSplitted[3], urlSplitted[4], urlSplitted[6], props.user.id, task.data.id)
+        props.fetchPullRequestData(urlSplitted[3], urlSplitted[4], urlSplitted[6], task.data.id)
       }, 2500))
     }
   }, [pullRequestURL])
@@ -50,7 +50,7 @@ const SendSolutionDrawer = props => {
 
   const submitTaskSolution = () => {
     if (editMode) {
-      const payload = { pullRequestURL: pullRequestURL, taskId: task.data.id, userId: props.user.id, taskSolutionId: taskSolution.id }
+      const payload = { pullRequestURL: pullRequestURL, taskId: task.data.id, taskSolutionId: taskSolution.id }
       props.updateTaskSolution(payload).then((solution) => {
         
       })
@@ -59,7 +59,7 @@ const SendSolutionDrawer = props => {
       return
     }
 
-    const payload = { ...pullRequestData, pullRequestURL: pullRequestURL, taskId: task.data.id, userId: props.user.id }
+    const payload = { ...pullRequestData, pullRequestURL: pullRequestURL, taskId: task.data.id }
 
     props.createTaskSolution(payload).then((solution) => {
       

--- a/frontend/src/containers/send-solution-drawer.js
+++ b/frontend/src/containers/send-solution-drawer.js
@@ -17,11 +17,11 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    getTaskSolution: (userId, taskId) => dispatch(getTaskSolution(userId, taskId)),
+    getTaskSolution: (taskId) => dispatch(getTaskSolution(taskId)),
     createTaskSolution: (taskSolution) => dispatch(createTaskSolution(taskSolution)),
     updateTaskSolution: (payload) => dispatch(updateTaskSolution(payload)),
-    fetchPullRequestData: (owner, repositoryName, pullRequestId, userId, taskId) => dispatch(
-      fetchPullRequestData(owner, repositoryName, pullRequestId, userId, taskId)
+    fetchPullRequestData: (owner, repositoryName, pullRequestId, taskId) => dispatch(
+      fetchPullRequestData(owner, repositoryName, pullRequestId, taskId)
     ),
     cleanPullRequestDataState: () => dispatch(cleanPullRequestDataState()),
     fetchAccount: () => dispatch(fetchAccount())

--- a/modules/app/controllers/taskSolution.js
+++ b/modules/app/controllers/taskSolution.js
@@ -1,7 +1,7 @@
 const Tasks = require('../../tasks')
 
 exports.getTaskSolution = (req, res) => {
-  Tasks.taskSolutionGet(req.query.taskId, req.query.userId)
+  Tasks.taskSolutionGet(req.query.taskId, req.user.id)
     .then(data => {
       res.send(data)
     }).catch(error => {
@@ -14,7 +14,7 @@ exports.getTaskSolution = (req, res) => {
 exports.fetchPullRequestData = (req, res) => {
   const params = {
     pullRequestId: req.query.pullRequestId,
-    userId: req.query.userId,
+    userId: req.user.id,
     repositoryName: req.query.repositoryName,
     owner: req.query.owner,
     taskId: req.query.taskId
@@ -30,7 +30,7 @@ exports.fetchPullRequestData = (req, res) => {
 }
 
 exports.createTaskSolution = (req, res) => {
-  Tasks.taskSolutionCreate(req.body)
+  Tasks.taskSolutionCreate({ ...req.body, userId: req.user.id })
     .then(data => {
       res.send(data)
     }).catch(error => {
@@ -41,7 +41,7 @@ exports.createTaskSolution = (req, res) => {
 }
 
 exports.updateTaskSolution = (req, res) => {
-  Tasks.taskSolutionUpdate(req.body, req.params.id).then(data => {
+  Tasks.taskSolutionUpdate({ ...req.body, userId: req.user.id }, req.params.id).then(data => {
     res.send(data)
   }).catch(error => {
     // eslint-disable-next-line no-console

--- a/test/taskSolution.test.js
+++ b/test/taskSolution.test.js
@@ -31,7 +31,6 @@ describe("Task Solution", () => {
       try {
         const solutionParams = {
           pullRequestId: '2',
-          userId: 1,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: 1
@@ -89,7 +88,6 @@ describe("Task Solution", () => {
             isIssueClosed: true,
             hasIssueReference: true,
             pullRequestURL: "https://github.com/alexanmtz/test-repository/pull/2",
-            userId: user.id,
             taskId: task.id
           });
         expect(taskSolutionCreateRes.body).to.have.property('id');
@@ -102,7 +100,6 @@ describe("Task Solution", () => {
       try {
         const solutionParams = {
           pullRequestId: '2',
-          userId: 1,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: 1
@@ -172,7 +169,6 @@ describe("Task Solution", () => {
             isIssueClosed: true,
             hasIssueReference: true,
             pullRequestURL: "https://github.com/alexanmtz/test-repository/pull/2",
-            userId: user.id,
             taskId: task.id
           });
         expect(taskSolutionCreateRes.statusCode).to.equal(400);
@@ -186,7 +182,6 @@ describe("Task Solution", () => {
       try {
         const solutionParams = {
           pullRequestId: '2',
-          userId: 1,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: 1
@@ -253,7 +248,6 @@ describe("Task Solution", () => {
             isIssueClosed: true,
             hasIssueReference: true,
             pullRequestURL: "https://github.com/alexanmtz/test-repository/pull/2",
-            userId: user.id,
             taskId: task.id
           });
         expect(taskSolutionUpdateRes.body).to.have.property('isConnectedToGitHub');
@@ -272,7 +266,6 @@ describe("Task Solution", () => {
       try {
         const solutionParams = {
           pullRequestId: '2',
-          userId: 1,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: 1
@@ -310,14 +303,13 @@ describe("Task Solution", () => {
 
         const params = {
           pullRequestId: solutionParams.pullRequestId,
-          userId: solutionParams.userId,
           repositoryName: solutionParams.repositoryName,
           owner: solutionParams.owner,
           taskId: solutionParams.taskId
         }
         // Send a GET request to fetch task solution data
         const taskSolutionFetchDataRes = await agent
-          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&userId=${params.userId}&taskId=${params.taskId}`)
+          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&taskId=${params.taskId}`)
           .set('Authorization', headers.authorization)
           .expect('Content-Type', /json/)
           .expect(200)
@@ -342,7 +334,6 @@ describe("Task Solution", () => {
       try {
         const solutionParams = {
           pullRequestId: '2',
-          userId: 1,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: 1
@@ -380,14 +371,13 @@ describe("Task Solution", () => {
 
         const params = {
           pullRequestId: solutionParams.pullRequestId,
-          userId: solutionParams.userId,
           repositoryName: solutionParams.repositoryName,
           owner: solutionParams.owner,
           taskId: solutionParams.taskId
         }
         // Send a GET request to fetch task solution data
         const taskSolutionFetchDataRes = await agent
-          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&userId=${params.userId}&taskId=${params.taskId}`)
+          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&taskId=${params.taskId}`)
           .set('Authorization', headers.authorization)
           .expect('Content-Type', /json/)
           .expect(200)
@@ -429,7 +419,6 @@ describe("Task Solution", () => {
 
         const solutionParams = {
           pullRequestId: '2',
-          userId: user.id,
           repositoryName: 'test-repository',
           owner: 'alexanmtz',
           taskId: task.id
@@ -451,14 +440,13 @@ describe("Task Solution", () => {
 
         const params = {
           pullRequestId: solutionParams.pullRequestId,
-          userId: solutionParams.userId,
           repositoryName: solutionParams.repositoryName,
           owner: solutionParams.owner,
           taskId: solutionParams.taskId
         }
         // Send a GET request to fetch task solution data
         const taskSolutionFetchDataRes = await agent
-          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&userId=${params.userId}&taskId=${params.taskId}`)
+          .get(`/tasksolutions/fetch/?owner=${params.owner}&repositoryName=${params.repositoryName}&pullRequestId=${params.pullRequestId}&taskId=${params.taskId}`)
           .set('Authorization', headers.authorization)
           .expect('Content-Type', /json/)
           .expect(200)


### PR DESCRIPTION
This pull request simplifies the handling of `userId` by removing it from the payloads and API requests in various parts of the application. Instead, the `userId` is now consistently derived from the authenticated user context (`req.user.id`) on the backend. The changes span across the frontend, backend, and test files, ensuring uniformity and reducing redundant data passing.

### Frontend Changes:
* Removed `userId` from the parameters of `getTaskSolution`, `fetchPullRequestData`, and `updateTaskSolution` functions in `frontend/src/actions/taskSolutionActions.js`. Updated API calls to exclude `userId` from query parameters. [[1]](diffhunk://#diff-06ac2231e87bd3922ba7745d36d725b9e5afd3ed55788addd2070ce837da96c3L45-R49) [[2]](diffhunk://#diff-06ac2231e87bd3922ba7745d36d725b9e5afd3ed55788addd2070ce837da96c3L80-R85) [[3]](diffhunk://#diff-06ac2231e87bd3922ba7745d36d725b9e5afd3ed55788addd2070ce837da96c3L141-R145)
* Updated `SendSolutionDrawer` component to exclude `userId` when calling `getTaskSolution`, `fetchPullRequestData`, and `updateTaskSolution`. Adjusted payloads accordingly. [[1]](diffhunk://#diff-bffdfac939a924cbf7e7546517c39e74bf422778cd3b935ab56d196c590e1f18L22-R22) [[2]](diffhunk://#diff-bffdfac939a924cbf7e7546517c39e74bf422778cd3b935ab56d196c590e1f18L34-R34) [[3]](diffhunk://#diff-bffdfac939a924cbf7e7546517c39e74bf422778cd3b935ab56d196c590e1f18L53-R53) [[4]](diffhunk://#diff-bffdfac939a924cbf7e7546517c39e74bf422778cd3b935ab56d196c590e1f18L62-R62)
* Modified `mapDispatchToProps` in `frontend/src/containers/send-solution-drawer.js` to remove `userId` from dispatched actions.

### Backend Changes:
* Updated controller methods in `modules/app/controllers/taskSolution.js` to derive `userId` from `req.user.id` instead of relying on it being passed in the request body or query parameters. [[1]](diffhunk://#diff-dd08f05fafc3baaa37becbcd97c2d70172e7dbe50cbb98756964f2bef5ddc034L4-R4) [[2]](diffhunk://#diff-dd08f05fafc3baaa37becbcd97c2d70172e7dbe50cbb98756964f2bef5ddc034L17-R17) [[3]](diffhunk://#diff-dd08f05fafc3baaa37becbcd97c2d70172e7dbe50cbb98756964f2bef5ddc034L33-R33) [[4]](diffhunk://#diff-dd08f05fafc3baaa37becbcd97c2d70172e7dbe50cbb98756964f2bef5ddc034L44-R44)

### Test Updates:
* Removed `userId` from test payloads and API calls in `test/taskSolution.test.js` to align with the updated backend logic. Adjusted assertions and test cases accordingly. [[1]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL34) [[2]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL92) [[3]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL105) [[4]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL175) [[5]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL189) [[6]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL256) [[7]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL275) [[8]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL313-R312) [[9]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL345) [[10]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL383-R380) [[11]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL432) [[12]](diffhunk://#diff-9b1f463ff4b1212e39cfd4fcf672090ba49fd0e90df1b3600b89f08d1623e0dbL454-R449)