### PR TITLE
Fix/balance card fix for amount types

### DIFF
--- a/frontend/src/components/areas/private/features/payouts/payouts.tsx
+++ b/frontend/src/components/areas/private/features/payouts/payouts.tsx
@@ -78,7 +78,7 @@ const Payouts = ({ payouts, balance, fetchAccountBalance, searchPayout, requestP
                   action={<FormattedMessage id="payouts.requestPayout" defaultMessage="Request payout" />}
                   actionProps={{ disabled: item.amount === 0 || payoutSchedule !== 'manual' }}
                   completed={completed}
-                  type='centavos'
+                  type="centavos"
                 />
                 <PayoutRequestDrawer
                   open={payoutRequestDrawer}

--- a/frontend/src/components/areas/private/features/payouts/payouts.tsx
+++ b/frontend/src/components/areas/private/features/payouts/payouts.tsx
@@ -78,6 +78,7 @@ const Payouts = ({ payouts, balance, fetchAccountBalance, searchPayout, requestP
                   action={<FormattedMessage id="payouts.requestPayout" defaultMessage="Request payout" />}
                   actionProps={{ disabled: item.amount === 0 || payoutSchedule !== 'manual' }}
                   completed={completed}
+                  type='centavos'
                 />
                 <PayoutRequestDrawer
                   open={payoutRequestDrawer}

--- a/frontend/src/components/areas/private/features/wallets/wallets.tsx
+++ b/frontend/src/components/areas/private/features/wallets/wallets.tsx
@@ -144,7 +144,8 @@ const Wallets = ({
         {wallet.data.id ? (
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end' }}>
             <BalanceCard
-              name={wallet.data.name || `Wallet #${wallet.id}`} balance={wallet.data.balance}
+              name={wallet.data.name || `Wallet #${wallet.id}`} 
+              balance={wallet.data.balance}
               onAdd={(e) => openAddFundsDialog(e)}
               action={<FormattedMessage id="wallets.addFunds" defaultMessage="Add funds" />}
               completed={wallet.completed}

--- a/frontend/src/components/design-library/molecules/cards/balance-card/balance-card.stories.tsx
+++ b/frontend/src/components/design-library/molecules/cards/balance-card/balance-card.stories.tsx
@@ -20,6 +20,11 @@ export const Default = Template.bind({});
 Default.args = {
 };
 
+export const Centavos = Template.bind({});
+Centavos.args = {
+  type: 'centavos'
+};
+
 export const Loading = Template.bind({});
 Loading.args = {
   completed: false

--- a/frontend/src/components/design-library/molecules/cards/balance-card/balance-card.tsx
+++ b/frontend/src/components/design-library/molecules/cards/balance-card/balance-card.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, CardContent, CardActions, Skeleton } from '@mui/material';
 import currencyMap from './currency-map';
 import { RootCard, Balance as BalanceText, Name as NameText } from './balance-card.styles'
+import { formatCurrency } from '../../../../../utils/format-currency'
 
 
 //Function to convert currency code to symbol
@@ -38,11 +39,12 @@ type BalanceCardProps = {
   action?: React.PropsWithChildren<any>;
   actionProps?: any;
   completed?: boolean;
+  type?: 'decimal' | 'centavos';
 }
 
-const BalanceCard = ({ name, balance, currency = 'USD', onAdd, action, actionProps, completed }: BalanceCardProps) => {
+const BalanceCard = ({ name, balance, currency = 'USD', onAdd, action, actionProps, completed, type = 'decimal' }: BalanceCardProps) => {
 
-  const convertedBalance = `${currencyCodeToSymbol(currency)} ${convertStripeAmountByCurrency(balance, currency)}`
+  const convertedBalance = type === 'decimal' ? formatCurrency(balance) :`${currencyCodeToSymbol(currency)} ${convertStripeAmountByCurrency(balance, currency)}`
 
   const isLoading = completed === false;
 

--- a/frontend/src/components/design-library/organisms/forms/payout-forms/payout-request-form/payout-request-form.tsx
+++ b/frontend/src/components/design-library/organisms/forms/payout-forms/payout-request-form/payout-request-form.tsx
@@ -87,7 +87,7 @@ const PayoutRequestForm = forwardRef<PayoutRequestFormHandle, PayoutRequestFormP
             actionProps={{ disabled: balance === 0 }}
             onAdd={handleAddBalance}
             completed={completed}
-            type='centavos'
+            type="centavos"
           />
         </Grid>
         <Grid size={{ xs: 12, md: 12 }}>

--- a/frontend/src/components/design-library/organisms/forms/payout-forms/payout-request-form/payout-request-form.tsx
+++ b/frontend/src/components/design-library/organisms/forms/payout-forms/payout-request-form/payout-request-form.tsx
@@ -37,7 +37,7 @@ const PayoutRequestForm = forwardRef<PayoutRequestFormHandle, PayoutRequestFormP
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const data = Object.fromEntries(formData.entries());
-    onSubmit?.(event, {...data, currency: currency, method: 'bank_account' });
+    onSubmit?.(event, { ...data, currency: currency, method: 'bank_account' });
   };
 
   const handleAddBalance = () => {
@@ -78,7 +78,7 @@ const PayoutRequestForm = forwardRef<PayoutRequestFormHandle, PayoutRequestFormP
   return (
     <form onSubmit={handleSubmit} ref={internalFormRef}>
       <Grid container spacing={2}>
-  <Grid size={{ xs: 12, md: 12 }} justifyContent="flex-end">
+        <Grid size={{ xs: 12, md: 12 }} justifyContent="flex-end">
           <BalanceCard
             name={<FormattedMessage id="PayoutRequest.form.title" defaultMessage="Available funds to payout to your account" />}
             balance={balance}
@@ -87,9 +87,10 @@ const PayoutRequestForm = forwardRef<PayoutRequestFormHandle, PayoutRequestFormP
             actionProps={{ disabled: balance === 0 }}
             onAdd={handleAddBalance}
             completed={completed}
+            type='centavos'
           />
         </Grid>
-  <Grid size={{ xs: 12, md: 12 }}>
+        <Grid size={{ xs: 12, md: 12 }}>
           <Field
             label="Amount"
             name="amount"
@@ -109,7 +110,7 @@ const PayoutRequestForm = forwardRef<PayoutRequestFormHandle, PayoutRequestFormP
             onChange={handleAmountChange}
           />
         </Grid>
-  <Grid size={{ xs: 12, md: 12 }}>
+        <Grid size={{ xs: 12, md: 12 }}>
           <Checkboxes
             checkboxes={[
               {


### PR DESCRIPTION
This pull request introduces a new `type` prop to the `BalanceCard` component, allowing for flexible formatting of currency display (either as decimal or centavos). The change is integrated across payout and wallet features, and is documented in the Storybook stories for `BalanceCard`.

**BalanceCard enhancements:**

* Added a `type` prop (`'decimal' | 'centavos'`) to `BalanceCard`, enabling selection between decimal and centavos currency formatting. The default is `'decimal'`.
* The `convertedBalance` logic now uses the new `type` prop to determine formatting: if `'decimal'`, it uses `formatCurrency`; if `'centavos'`, it uses the existing currency conversion logic.
* Imported `formatCurrency` utility to support decimal formatting.

**Feature integration:**

* Passed `type="centavos"` to `BalanceCard` in both payouts and payout request form components, ensuring centavos formatting in relevant contexts. [[1]](diffhunk://#diff-2a7c357c74ac99997fea3c9e64f24455a552c58c595ab8ed4259f930d531b4f8R81) [[2]](diffhunk://#diff-9fcce9a958b60a38a636eb88843a5c6829af5248d7e57a32fdf368ddd35a09daR90)

**Documentation and Storybook:**

* Added a new `Centavos` story to `balance-card.stories.tsx` to demonstrate the new formatting option.

**Minor code style/clarity:**

* Improved prop formatting for `BalanceCard` in the wallets feature for readability.