### PR TITLE
handling amount convertion in centavos

### DIFF
--- a/modules/util/handle-amount/handle-amount.js
+++ b/modules/util/handle-amount/handle-amount.js
@@ -13,7 +13,7 @@ function handleAmount(amount, percent, type, currency = 'usd') {
   
   const percentDecimal = new Decimal(1).minus(new Decimal(percent).div(100));
   const resultDecimal = decimalAmount.mul(percentDecimal);
-  const centavos = resultDecimal.mul(centsFactor).toDecimalPlaces(decimalPlaces, Decimal.ROUND_HALF_UP).toNumber();
+  const centavos = resultDecimal.mul(centsFactor).toDecimalPlaces(0, Decimal.ROUND_HALF_UP).toNumber();
   const decimal = resultDecimal.toNumber();
   return { centavos, decimal };
 }

--- a/test/handle-amount.test.js
+++ b/test/handle-amount.test.js
@@ -53,4 +53,9 @@ describe('Amount Conversion', () => {
     expect(result.centavos).to.equal(92);
     expect(result.decimal).to.equal(0.92);
   });
+  it('should apply 8 percent for an amount that will cause rounding', () => {
+    const result = handleAmount(4995, 8, 'centavos');
+    expect(result.centavos).to.equal(4595);
+    expect(result.decimal).to.equal(45.954);
+  });
 });


### PR DESCRIPTION
This pull request updates the rounding logic in the `handleAmount` utility function and adds a new test case to ensure correct behavior when applying percentages that cause rounding. The main changes are:

**Rounding Logic Update:**

* The `centavos` value in `handleAmount` is now always rounded to the nearest whole number, regardless of the currency's decimal places. This ensures consistency and accuracy when converting amounts.

**Test Coverage Improvements:**

* Added a new test to verify that applying an 8 percent deduction to an amount results in correct rounding for both `centavos` and `decimal` values.