### PR TITLE
new payment status and transfer components

### DIFF
--- a/frontend/src/components/areas/private/features/claims/claims.tsx
+++ b/frontend/src/components/areas/private/features/claims/claims.tsx
@@ -5,6 +5,7 @@ import IssueLinkField from 'design-library/molecules/tables/section-table/sectio
 import CreatedField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/created-field/created-field';
 import AmountField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/amount-field/amount-field';
 import TextField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/text-field/text-field';
+import TransferStatusField from 'design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field';
 
 const Claims = ({
   user,
@@ -38,6 +39,11 @@ const Claims = ({
               createdAt: { sortable: true, numeric: true, dataBaseKey: 'createdAt', label: <FormattedMessage id="account.profile.claims.createdAt" defaultMessage="Created At" /> }
             },
             customColumnRenderer: {
+              status: (item:any) => (
+                <TransferStatusField
+                  status={item.status}
+                />
+              ),
               issue: (item) => (
                 <IssueLinkField
                   issue={item?.Task}
@@ -69,6 +75,11 @@ const Claims = ({
               createdAt: { sortable: true, numeric: true, dataBaseKey: 'createdAt', label: <FormattedMessage id="account.profile.claims.createdAt" defaultMessage="Created At" /> }
             },
             customColumnRenderer: {
+              status: (item:any) => (
+                <TransferStatusField
+                  status={item.status}
+                />
+              ),
               title: (item:any) => (
                 <TextField
                   title={item?.PaymentRequest?.title}

--- a/frontend/src/components/areas/private/features/payouts/payouts-table.tsx
+++ b/frontend/src/components/areas/private/features/payouts/payouts-table.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { convertStripeAmountByCurrency, currencyCodeToSymbol } from 'design-library/molecules/cards/balance-card/balance-card';
 import SectionTable from 'design-library/molecules/tables/section-table/section-table';
 import AmountField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/amount-field/amount-field';
-import StatusField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/status-field/status-field'
+import PayoutStatusField from 'design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field';
 import CreatedField from 'design-library/molecules/tables/section-table/section-table-custom-fields/base/created-field/created-field';
 
 const PayoutsTable = ({ payouts }) => {
@@ -16,7 +16,7 @@ const PayoutsTable = ({ payouts }) => {
 
   const customColumnRenderer = {
     status: (item: any) => (
-      <StatusField status={item.status} />
+      <PayoutStatusField status={item.status} />
     ),
     method: (item: any) => (
       <span>{item.method || 'No method available'}</span>

--- a/frontend/src/components/design-library/atoms/status/payout-status/payout-status.stories.tsx
+++ b/frontend/src/components/design-library/atoms/status/payout-status/payout-status.stories.tsx
@@ -1,0 +1,56 @@
+import PayoutStatus from './payout-status';
+
+export default {
+  title: 'Design Library/Atoms/Status/Payouts/PayoutStatus',
+  component: PayoutStatus
+};
+
+export const Pending = {
+  args: {
+    status: 'pending'
+  }
+};
+
+export const Created = {
+  args: {
+    status: 'created'
+  }
+};
+
+export const InTransit = {
+  args: {
+    status: 'in_transit'
+  }
+};
+
+export const failed = {
+  args: {
+    status: 'failed'
+  }
+};
+
+export const Canceled = {
+  args: {
+    status: 'canceled'
+  }
+};
+
+export const Paid = {
+  args: {
+    status: 'paid'
+  }
+};
+
+export const Unknown = {
+  args: {
+    status: 'unknown'
+  }
+};
+
+export const Loading = {
+  args: {
+    status: 'pending',
+    completed: false
+  }
+};
+

--- a/frontend/src/components/design-library/atoms/status/payout-status/payout-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/payout-status/payout-status.styles.ts
@@ -1,0 +1,70 @@
+import { styled } from '@mui/material/styles'
+import { green, orange, red } from '@mui/material/colors'
+
+// Prefix-based class names to keep compatibility with components expecting `classes[color]`
+const PREFIX = 'PayoutStatus'
+
+export const classes = {
+  pending: `${PREFIX}-pending`,
+  created: `${PREFIX}-created`,
+  in_transit: `${PREFIX}-in_transit`,
+  failed: `${PREFIX}-failed`,
+  canceled: `${PREFIX}-canceled`,
+  paid: `${PREFIX}-paid`,
+  unknown: `${PREFIX}-unknown`
+} as const
+
+// Root wrapper that provides styles for the classnames above
+export const PayoutStatusRoot = styled('div')(({ theme }) => ({
+  [`.${classes.pending}`]: {
+    backgroundColor: orange[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.created}`]: {
+    backgroundColor: green[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.in_transit}`]: {
+    backgroundColor: orange[700],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.failed}`]: {
+    backgroundColor: red[700],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.canceled}`]: {
+    backgroundColor: red[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.paid}`]: {
+    backgroundColor: green[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.unknown}`]: {
+    backgroundColor: theme.palette.grey[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  }
+}))
+
+export default classes

--- a/frontend/src/components/design-library/atoms/status/payout-status/payout-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/payout-status/payout-status.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { 
+  CheckCircleOutlineTwoTone as ActiveIcon,
+  NewLabel as CreatedIcon,
+  AltRoute as InTransitIcon,
+  NotInterested as CanceledIcon,
+  MoneyOff as FailedIcon,
+  InfoSharp as InfoIcon,
+  HelpOutline as QuestionInfoIcon
+} from '@mui/icons-material';
+import classes, { PayoutStatusRoot  } from './payout-status.styles';
+import BaseStatus from 'design-library/atoms/status/base-status/base-status';
+
+const PayoutStatus = ({ status, completed = true }) => {
+
+    const statusList = [
+      { status: 'pending', label: 'Pending', color: 'pending', icon: <InfoIcon className={classes.pending} />, message: 'Your payout is pending. Please come back later to see the latest status.' },
+      { status: 'created', label: 'Created', color: 'created', icon: <CreatedIcon className={classes.created} /> },
+      { status: 'in_transit', label: 'In Transit', color: 'in_transit', icon: <InTransitIcon className={classes.in_transit} />, message: 'Your payout is in transit and will be in your bank account soon.' },
+      { status: 'failed', label: 'Failed', color: 'failed', icon: <FailedIcon className={classes.failed} />, message: 'Your payout was failed. Please check with your bank for more details.' },
+      { status: 'canceled', label: 'Canceled', color: 'canceled', icon: <CanceledIcon className={classes.canceled} />, message: 'Your payout was canceled. Please check with your bank for more details.' },
+      { status: 'paid', label: 'Paid', color: 'paid', icon: <ActiveIcon className={classes.paid} />, message: 'Your status is paid, it means is already in your bank account.' },
+      { status: 'unknown', label: 'Unknown', color: 'unknown', icon: <QuestionInfoIcon className={classes.unknown} />, message: 'Your status is unknown. Please check back later.' }
+    ];
+  return (
+    <PayoutStatusRoot>
+      <BaseStatus
+        classes={classes}
+        status={status}
+        statusList={statusList}
+        completed={completed}
+      />
+    </PayoutStatusRoot>
+  );
+}
+
+export default PayoutStatus;

--- a/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.stories.tsx
+++ b/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.stories.tsx
@@ -1,0 +1,50 @@
+import TransferStatus from './transfer-status';
+
+export default {
+  title: 'Design Library/Atoms/Status/Transfer/TransferStatus',
+  component: TransferStatus
+};
+
+export const Pending = {
+  args: {
+    status: 'pending'
+  }
+};
+
+export const Created = {
+  args: {
+    status: 'created'
+  }
+};
+
+export const InTransit = {
+  args: {
+    status: 'in_transit'
+  }
+};
+
+export const Reversed = {
+  args: {
+    status: 'reversed'
+  }
+};
+
+export const Completed = {
+  args: {
+    status: 'completed'
+  }
+};
+
+export const Unknown = {
+  args: {
+    status: 'unknown'
+  }
+};
+
+export const Loading = {
+  args: {
+    status: 'pending',
+    completed: false
+  }
+};
+

--- a/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.styles.ts
+++ b/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.styles.ts
@@ -1,0 +1,62 @@
+import { styled } from '@mui/material/styles'
+import { green, orange, red } from '@mui/material/colors'
+
+// Prefix-based class names to keep compatibility with components expecting `classes[color]`
+const PREFIX = 'PayoutStatus'
+
+export const classes = {
+  pending: `${PREFIX}-pending`,
+  created: `${PREFIX}-created`,
+  in_transit: `${PREFIX}-in_transit`,
+  reversed: `${PREFIX}-reversed`,
+  completed: `${PREFIX}-completed`,
+  unknown: `${PREFIX}-unknown`
+} as const
+
+// Root wrapper that provides styles for the classnames above
+export const TransferStatusRoot = styled('div')(({ theme }) => ({
+  [`.${classes.pending}`]: {
+    backgroundColor: orange[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.created}`]: {
+    backgroundColor: green[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.in_transit}`]: {
+    backgroundColor: orange[700],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.reversed}`]: {
+    backgroundColor: red[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.completed}`]: {
+    backgroundColor: green[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  },
+  [`.${classes.unknown}`]: {
+    backgroundColor: theme.palette.grey[500],
+    color: theme.palette.common.white,
+    '& .MuiSvgIcon-root': {
+      color: theme.palette.common.white
+    }
+  }
+}))
+
+export default classes

--- a/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.tsx
+++ b/frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { 
+  CheckCircleOutlineTwoTone as CompletedIcon,
+  NewLabel as CreatedIcon,
+  ImportExport as ReversedIcon,
+  AltRoute as InTransitIcon,
+  InfoSharp as InfoIcon,
+  HelpOutline as QuestionInfoIcon
+} from '@mui/icons-material';
+import classes, { TransferStatusRoot  } from './transfer-status.styles';
+import BaseStatus from 'design-library/atoms/status/base-status/base-status';
+
+const TransferStatus = ({ status, completed = true }) => {
+
+    const statusList = [
+      { status: 'pending', label: 'Pending', color: 'pending', icon: <InfoIcon className={classes.pending} />, message: 'Your payout is pending. Please come back later to see the latest status.' },
+      { status: 'created', label: 'Created', color: 'created', icon: <CreatedIcon className={classes.created} /> },
+      { status: 'in_transit', label: 'In Transit', color: 'in_transit', icon: <InTransitIcon className={classes.in_transit} />, message: 'Your payout is in transit. Please come back later to see the latest status.' },
+      { status: 'reversed', label: 'Reversed', color: 'reversed', icon: <ReversedIcon className={classes.reversed} />, message: 'Your payout was reversed. Please contact support for more information.' },
+      { status: 'completed', label: 'Completed', color: 'completed', icon: <CompletedIcon className={classes.completed} />, message: 'Your payout is completed and should be in your bank account.' },
+      { status: 'unknown', label: 'Unknown', color: 'unknown', icon: <QuestionInfoIcon className={classes.unknown} />, message: 'Your status is unknown. Please check back later.' }
+    ];
+  return (
+    <TransferStatusRoot>
+      <BaseStatus
+        classes={classes}
+        status={status}
+        statusList={statusList}
+        completed={completed}
+      />
+    </TransferStatusRoot>
+  );
+}
+
+export default TransferStatus;

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.stories.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.stories.tsx
@@ -1,0 +1,56 @@
+import PayoutStatusField from './payout-status-field';
+
+export default {
+  title: 'Design Library/Molecules/Tables/Fields/Payouts/PayoutStatusField',
+  component: PayoutStatusField
+};
+
+export const Pending = {
+  args: {
+    status: 'pending'
+  }
+};
+
+export const Created = {
+  args: {
+    status: 'created'
+  }
+};
+
+export const InTransit = {
+  args: {
+    status: 'in_transit'
+  }
+};
+
+export const Failed = {
+  args: {
+    status: 'failed'
+  }
+};
+
+export const Canceled = {
+  args: {
+    status: 'canceled'
+  }
+};
+
+export const Paid = {
+  args: {
+    status: 'paid'
+  }
+};
+
+export const Unknown = {
+  args: {
+    status: 'unknown'
+  }
+};
+
+export const Loading = {
+  args: {
+    status: 'pending',
+    completed: false
+  }
+};
+

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import PayoutStatus from 'design-library/atoms/status/payout-status/payout-status';
+
+const PayoutStatusField = ({ status }) => {
+
+  return (
+    <PayoutStatus status={status} />
+  );
+}
+
+export default PayoutStatusField;

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.stories.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.stories.tsx
@@ -1,0 +1,49 @@
+import TransferStatusField from './transfer-status-field';
+
+export default {
+  title: 'Design Library/Molecules/Tables/Fields/Transfers/TransferStatusField',
+  component: TransferStatusField
+};
+
+export const Pending = {
+  args: {
+    status: 'pending'
+  }
+};
+
+export const Created = {
+  args: {
+    status: 'created'
+  }
+};
+
+export const InTransit = {
+  args: {
+    status: 'in_transit'
+  }
+};
+
+export const Reversed = {
+  args: {
+    status: 'reversed'
+  }
+};
+
+export const Completed = {
+  args: {
+    status: 'completed'
+  }
+};
+
+export const Unknown = {
+  args: {
+    status: 'unknown'
+  }
+};
+
+export const Loading = {
+  args: {
+    status: 'pending',
+    completed: false
+  }
+};

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import TransferStatus from 'design-library/atoms/status/transfer-status/transfer-status';
+
+const TransferStatusField = ({ status }) => {
+
+  return (
+    <TransferStatus status={status} />
+  );
+}
+
+export default TransferStatusField;


### PR DESCRIPTION
This pull request introduces new, specialized status components for payout and transfer records, and integrates them into the claims and payouts tables in the frontend. The changes improve the clarity and consistency of status displays by replacing generic status fields with custom-designed components and styles, and add Storybook stories for easier UI testing and documentation.

**Status Component Enhancements**

* Added new `PayoutStatus` and `TransferStatus` atom components, each with custom icons, labels, color-coded styles, and status messages for various payout/transfer states. These components use a shared `BaseStatus` for consistent rendering. (`frontend/src/components/design-library/atoms/status/payout-status/payout-status.tsx` [[1]](diffhunk://#diff-b0382a982b3f1cc8acec307fc39bd43152a0cdd8b5526fe9719ba7d5dfa3e550R1-R37) `frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.tsx` [[2]](diffhunk://#diff-da99b8c0f0220c410a50990371519a6ff1010ab3ccec4ee33a1d66a7f6ea01fdR1-R35)
* Created corresponding style files for each status component, defining themed color schemes and class names for each status type. (`frontend/src/components/design-library/atoms/status/payout-status/payout-status.styles.ts` [[1]](diffhunk://#diff-3d07a9109b68dc493450e053bb24e31a2a55cd5b1198a7c843ef7f4e9f5c2aeaR1-R70) `frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.styles.ts` [[2]](diffhunk://#diff-e669e20bd51183df8df976e48f39402c3844f3133ad119b5c346ed1fb77c77b2R1-R62)

**Table Integration**

* Replaced the generic `StatusField` in the payouts table with the new `PayoutStatusField`, which uses the `PayoutStatus` component for improved status rendering. (`frontend/src/components/areas/private/features/payouts/payouts-table.tsx` [[1]](diffhunk://#diff-30d27d770f22ba6f04e66f3573f9ed03e6a6a05c8e4d6ee239e673178588c124L5-R5) [[2]](diffhunk://#diff-30d27d770f22ba6f04e66f3573f9ed03e6a6a05c8e4d6ee239e673178588c124L19-R19) `frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.tsx` [[3]](diffhunk://#diff-8238e5c395e77d0b216608b3daf5c4bf3f6fffcb88bd0a27c7b8dc5fed5fce4dR1-R11)
* Integrated the new `TransferStatusField` component into the claims table, enabling transfer status to be displayed with the enhanced UI. (`frontend/src/components/areas/private/features/claims/claims.tsx` [[1]](diffhunk://#diff-3b89d1dd41104ef58fbd3da6da8ddffb9b9b108ef4d2e9176c57684b02587942R8) [[2]](diffhunk://#diff-3b89d1dd41104ef58fbd3da6da8ddffb9b9b108ef4d2e9176c57684b02587942R42-R46) [[3]](diffhunk://#diff-3b89d1dd41104ef58fbd3da6da8ddffb9b9b108ef4d2e9176c57684b02587942R78-R82) `frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.tsx` [[4]](diffhunk://#diff-f4a4d7e9b1cc762f00ea90b623953226621e1ab7f2897c619ee8584994d95574R1-R11)

**Storybook Documentation**

* Added Storybook stories for both atom and field status components, covering all status variants for payouts and transfers, to facilitate UI development and testing. (`frontend/src/components/design-library/atoms/status/payout-status/payout-status.stories.tsx` [[1]](diffhunk://#diff-c233c7502aae7e42b22ea3665b0365b653d27bafaeb9d6848b0f66c69bf3ffb6R1-R56) `frontend/src/components/design-library/atoms/status/transfer-status/transfer-status.stories.tsx` [[2]](diffhunk://#diff-8c83efd6d539200b3b3af3934f31705166068d236a6d45aaa751a6aac714799dR1-R50) `frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/payouts/payout-status-field/payout-status-field.stories.tsx` [[3]](diffhunk://#diff-550d7e591c262f1c29e8a10663156a884c969093445be3e6876d01c49b5a091bR1-R56) `frontend/src/components/design-library/molecules/tables/section-table/section-table-custom-fields/transfer/transfer-status-field/transfer-status-field.stories.tsx` [[4]](diffhunk://#diff-cd9377412c719d507848ec39523f2b8289dcce05e50c329501c1f95d3cc38525R1-R49)