### PR TITLE
Fix typos in README and error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can do this with: `cp .env.example .env`
 1. Install by running the following command: `brew install postgres`
 2. Start the command service by running the following command: `brew services start postgresql`
 3. Create a postgres user by running the following command: `createuser postgres -s`
-4. Login into the Postgres cli with by running the following command: `psql -U postgres`
+4. Login into the Postgres cli by running the following command: `psql -U postgres`
 5. Create a test database by typing the following command: `create database gitpay_test;`
 6. Create a dev database by running the following command: `create database gitpay_dev;`
 7. Run this command to exit: `\q`
@@ -133,7 +133,7 @@ Then you can access at http://localhost:8082
 
 ### Activating user account locally
 
-When you run your backend node server, the e-mail notifications will output in your console, so when setup a new user, you should look for the activation link:
+When you run your backend node server, the e-mail notifications will output in your console, so when setting up a new user, you should look for the activation link:
 
 ```
  ----- email / subject ----

--- a/src/modules/users/userChangePassword.js
+++ b/src/modules/users/userChangePassword.js
@@ -36,7 +36,7 @@ module.exports = Promise.method(function userChangePassword (userParameters) {
 
       const passwordIsValid = foundUser.verifyPassword(oldPassword, existingPassword)
       if (!passwordIsValid) {
-        throw new Error('user.password.incorerct.current')
+        throw new Error('user.password.incorrect.current')
       }
 
       const passwordHash = models.User.generateHash(newPassword)


### PR DESCRIPTION
 ## Description
  Fixed spelling and grammar errors in documentation and error message translation key.

  ## Solution
  - **userChangePassword.js:39** - Corrected `incorerct` → `incorrect` in error translation key
  - **README.md:61** - Removed redundant word: "cli with by" → "cli by"
  - **README.md:136** - Fixed grammar: "when setup" → "when setting up"