### PR TITLE
Fix the wrong URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/briandk/transcriptase-atom/issues)
+## Report bugs using GitHub's [issues](https://github.com/worknenjoy/gitpay/issues)
 
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
 


### PR DESCRIPTION
## Description

**Broken issues link**: CONTRIBUTING.md pointed to wrong repo (`briandk/transcriptase-atom`) instead of `worknenjoy/gitpay`
