### PR TITLE
Redirect private task OAuth failures to dashboard

### DIFF
--- a/src/app/controllers/user/user.ts
+++ b/src/app/controllers/user/user.ts
@@ -126,6 +126,12 @@ export const createPrivateTask = async (req: any, res: any) => {
   const { url, code, userId } = req.query
   const githubClientId = secrets.github.id
   const githubClientSecret = secrets.github.secret
+  const redirectPrivateTaskError = (message?: string) => {
+    const encodedError = encodeURIComponent(message || 'We could not import the issue.')
+    return res.redirect(
+      `${process.env.FRONTEND_HOST}/#/profile?createTaskError=true&message=${encodedError}`
+    )
+  }
   try {
     const response = await requestPromise({
       method: 'POST',
@@ -164,15 +170,12 @@ export const createPrivateTask = async (req: any, res: any) => {
         const isRateLimit =
           String(errorStatus) === '403' || /rate limit exceeded/i.test(errorMessage || '')
         const finalError = isRateLimit ? 'API limit reached, please try again later.' : errorMessage
-        const encodedError = encodeURIComponent(finalError || 'We could not import the issue.')
-        return res.redirect(
-          `${process.env.FRONTEND_HOST}/#/profile?createTaskError=true&message=${encodedError}`
-        )
+        return redirectPrivateTaskError(finalError)
       }
     }
-    return res.status(response.access_token ? 200 : 401).send(response)
+    return redirectPrivateTaskError(response?.error_description || response?.error)
   } catch (e: any) {
-    return res.status(401).send(e)
+    return redirectPrivateTaskError(e?.message || e?.error?.message)
   }
 }
 

--- a/test/api/task/taskCrud.test.ts
+++ b/test/api/task/taskCrud.test.ts
@@ -63,6 +63,17 @@ const nockAuthLimitExceeded = () => {
     .reply(200, getSingleRepo.repo)
 }
 
+const nockAuthInvalidCode = () => {
+  nock('https://github.com')
+    .persist()
+    .post('/login/oauth/access_token/', { code: 'eb518274e906c68580f7' })
+    .basicAuth({ user: secrets.github.id, pass: secrets.github.secret })
+    .reply(200, {
+      error: 'bad_verification_code',
+      error_description: 'The code passed is incorrect or expired.'
+    })
+}
+
 describe('Task CRUD', () => {
   const createTask = async (authorizationHeader: string, params?: any) => {
     const res = await agent
@@ -237,6 +248,7 @@ describe('Task CRUD', () => {
   })
 
   it('should redirect to profile with an error when private task auth returns an invalid code', async () => {
+    nockAuthInvalidCode()
     const res = await agent
       .get(
         '/callback/github/private/?userId=1&url=https%3A%2F%2Fgithub.com%2Falexanmtz%2Ffestifica%2Fissues%2F1&code=eb518274e906c68580f7'
@@ -245,7 +257,9 @@ describe('Task CRUD', () => {
 
     expect(res.statusCode).to.equal(302)
     expect(res.headers.location).to.equal(
-      `${process.env.FRONTEND_HOST}/#/profile?createTaskError=true&message=bad_verification_code`
+      `${process.env.FRONTEND_HOST}/#/profile?createTaskError=true&message=${encodeURIComponent(
+        'The code passed is incorrect or expired.'
+      )}`
     )
   })
 

--- a/test/api/task/taskCrud.test.ts
+++ b/test/api/task/taskCrud.test.ts
@@ -236,16 +236,17 @@ describe('Task CRUD', () => {
     expect(mailSpySuccess).to.have.been.called()
   })
 
-  xit('should receive code on the platform from github auth to the redirected url for private tasks but invalid code', async () => {
+  it('should redirect to profile with an error when private task auth returns an invalid code', async () => {
     const res = await agent
       .get(
         '/callback/github/private/?userId=1&url=https%3A%2F%2Fgithub.com%2Falexanmtz%2Ffestifica%2Fissues%2F1&code=eb518274e906c68580f7'
       )
-      .expect(401)
+      .expect(302)
 
-    expect(res.statusCode).to.equal(401)
-    expect(res.body.error).to.equal('bad_verification_code')
-    expect(res.body).to.exist
+    expect(res.statusCode).to.equal(302)
+    expect(res.headers.location).to.equal(
+      `${process.env.FRONTEND_HOST}/#/profile?createTaskError=true&message=bad_verification_code`
+    )
   })
 
   it('should receive code on the platform from github auth to the redirected url for private tasks with a valid code', async () => {


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                                       
  This PR completes the private task OAuth error flow by redirecting invalid GitHub callback failures back to the dashboard instead of returning a raw `401` response.                                 
                                                                                                                                                                                                       
  ## Changes                                                                                                                                                                                           

  - redirect private task OAuth failures to `/#/profile?createTaskError=true`
  - reuse the existing dashboard error notification flow                                                                                                                                               
  - enable and update the invalid code test to assert the redirect behavior
                                                                                                                                                                                                       
  ## Why                                                                                                                                                                                               
                                                                                                                                                                                                       
  The success path already redirects the user back to the product, and part of the failure path was previously aligned with that behavior. This change covers the remaining failure branches so users do not get stuck on an API error response page.