### PR TITLE
Feat/server side pagination task list continued

### DIFF
--- a/frontend/src/components/areas/private/features/issues/pages/my-organization-issues-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/my-organization-issues-page.tsx
@@ -11,13 +11,7 @@ const TAB_TO_PARAM: Record<string, string> = {
 
 const DEFAULT_ROWS_PER_PAGE = 10
 
-const MyOrganizationIssuesPage = ({
-  user,
-  organization,
-  issues,
-  listTasks,
-  fetchOrganization
-}) => {
+const MyOrganizationIssuesPage = ({ user, organization, issues, listTasks, fetchOrganization }) => {
   const { filter, organization_id } = useParams<{ filter: string; organization_id: string }>()
   const [page, setPage] = React.useState(0)
   const [rowsPerPage, setRowsPerPage] = React.useState(DEFAULT_ROWS_PER_PAGE)
@@ -28,7 +22,12 @@ const MyOrganizationIssuesPage = ({
   const userId = user?.data?.id
 
   const fetchIssues = useCallback(
-    (pageOverride?: number, rowsOverride?: number, sortOverride?: typeof currentSort, filterOverride?: string) => {
+    (
+      pageOverride?: number,
+      rowsOverride?: number,
+      sortOverride?: typeof currentSort,
+      filterOverride?: string
+    ) => {
       if (!userId) return
       const activePage = pageOverride ?? page
       const activeRows = rowsOverride ?? rowsPerPage

--- a/frontend/src/components/areas/private/features/issues/pages/my-organization-issues-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/my-organization-issues-page.tsx
@@ -1,49 +1,114 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import MyOrganizationIssuesPrivatePage from 'design-library/pages/private-pages/organization-pages/my-organization-issues-private-page/my-organization-issues-private-page'
 import { useParams } from 'react-router'
+
+const TAB_TO_PARAM: Record<string, string> = {
+  createdbyme: 'userId',
+  assigned: 'assignedTo',
+  interested: 'interestedUserId',
+  supported: 'supportedByUserId'
+}
+
+const DEFAULT_ROWS_PER_PAGE = 10
 
 const MyOrganizationIssuesPage = ({
   user,
   organization,
   issues,
   listTasks,
-  filterTasks,
   fetchOrganization
 }) => {
   const { filter, organization_id } = useParams<{ filter: string; organization_id: string }>()
+  const [page, setPage] = React.useState(0)
+  const [rowsPerPage, setRowsPerPage] = React.useState(DEFAULT_ROWS_PER_PAGE)
+  const [currentSort, setCurrentSort] = React.useState<{ sortBy?: string; sortDirection?: string }>(
+    {}
+  )
 
-  const getFilteredIssues = (filter) => {
-    switch (filter) {
-      case 'assigned':
-        filterTasks('Assigns')
-        break
-      case 'createdbyme':
-        filterTasks('userId')
-        break
-      case 'interested':
-        filterTasks('assigned')
-        break
-      case 'supported':
-        filterTasks('supported')
-        break
-      default:
-        filterTasks('userId')
-        break
-    }
-  }
+  const userId = user?.data?.id
+
+  const fetchIssues = useCallback(
+    (pageOverride?: number, rowsOverride?: number, sortOverride?: typeof currentSort, filterOverride?: string) => {
+      if (!userId) return
+      const activePage = pageOverride ?? page
+      const activeRows = rowsOverride ?? rowsPerPage
+      const activeSort = sortOverride ?? currentSort
+      const activeFilter = filterOverride ?? filter
+      const paramKey = TAB_TO_PARAM[activeFilter] ?? 'userId'
+      listTasks({
+        organizationId: organization_id,
+        [paramKey]: userId,
+        page: activePage,
+        limit: activeRows,
+        ...(activeSort.sortBy ? activeSort : {})
+      })
+    },
+    [userId, filter, page, rowsPerPage, currentSort, listTasks, organization_id]
+  )
 
   useEffect(() => {
     fetchOrganization(organization_id)
   }, [organization_id])
 
   useEffect(() => {
-    listTasks({ organizationId: organization_id })
-  }, [organization_id])
+    if (userId) {
+      setPage(0)
+      fetchIssues(0, rowsPerPage, {})
+    }
+  }, [userId, organization_id])
 
   useEffect(() => {
-    getFilteredIssues(filter)
+    if (userId) {
+      setPage(0)
+      setCurrentSort({})
+      fetchIssues(0, rowsPerPage, {}, filter)
+    }
   }, [filter])
 
-  return <MyOrganizationIssuesPrivatePage organization={organization} user={user} issues={issues} />
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      setPage(newPage)
+      fetchIssues(newPage, rowsPerPage, currentSort)
+    },
+    [fetchIssues, rowsPerPage, currentSort]
+  )
+
+  const handleRowsPerPageChange = useCallback(
+    (newRowsPerPage: number) => {
+      setRowsPerPage(newRowsPerPage)
+      setPage(0)
+      fetchIssues(0, newRowsPerPage, currentSort)
+    },
+    [fetchIssues, currentSort]
+  )
+
+  const handleSortChange = useCallback(
+    (sortBy: string, sortDirection: 'asc' | 'desc' | 'none') => {
+      const newSort = sortDirection === 'none' ? {} : { sortBy, sortDirection }
+      setCurrentSort(newSort)
+      setPage(0)
+      fetchIssues(0, rowsPerPage, newSort)
+    },
+    [fetchIssues, rowsPerPage]
+  )
+
+  const serverSidePagination = {
+    enabled: true,
+    totalCount: issues.totalCount ?? 0,
+    page,
+    rowsPerPage,
+    onPageChange: handlePageChange,
+    onRowsPerPageChange: handleRowsPerPageChange,
+    onSortChange: handleSortChange
+  }
+
+  return (
+    <MyOrganizationIssuesPrivatePage
+      organization={organization}
+      user={user}
+      issues={issues}
+      serverSidePagination={serverSidePagination}
+    />
+  )
 }
 export default MyOrganizationIssuesPage

--- a/frontend/src/components/areas/private/features/issues/pages/my-project-issues-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/my-project-issues-page.tsx
@@ -23,7 +23,12 @@ const MyProjectIssuesPage = ({ user, project, issues, listTasks, fetchProject })
   const userId = user?.data?.id
 
   const fetchIssues = useCallback(
-    (pageOverride?: number, rowsOverride?: number, sortOverride?: typeof currentSort, filterOverride?: string) => {
+    (
+      pageOverride?: number,
+      rowsOverride?: number,
+      sortOverride?: typeof currentSort,
+      filterOverride?: string
+    ) => {
       if (!userId) return
       const activePage = pageOverride ?? page
       const activeRows = rowsOverride ?? rowsPerPage

--- a/frontend/src/components/areas/private/features/issues/pages/my-project-issues-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/my-project-issues-page.tsx
@@ -1,43 +1,109 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import MyProjectIssuesPrivatePage from 'design-library/pages/private-pages/project-pages/my-project-issues-private-page/my-project-issues-private-page'
 import { useHistory, useParams } from 'react-router'
 
-const MyProjectIssuesPage = ({ user, project, issues, listTasks, filterTasks, fetchProject }) => {
+const TAB_TO_PARAM: Record<string, string> = {
+  createdbyme: 'userId',
+  assigned: 'assignedTo',
+  interested: 'interestedUserId',
+  supported: 'supportedByUserId'
+}
+
+const DEFAULT_ROWS_PER_PAGE = 10
+
+const MyProjectIssuesPage = ({ user, project, issues, listTasks, fetchProject }) => {
   const history = useHistory()
   const { filter, project_id } = useParams<{ filter: string; project_id: string }>()
+  const [page, setPage] = React.useState(0)
+  const [rowsPerPage, setRowsPerPage] = React.useState(DEFAULT_ROWS_PER_PAGE)
+  const [currentSort, setCurrentSort] = React.useState<{ sortBy?: string; sortDirection?: string }>(
+    {}
+  )
 
-  const getFilteredIssues = (filter) => {
-    switch (filter) {
-      case 'assigned':
-        filterTasks('Assigns')
-        break
-      case 'createdbyme':
-        filterTasks('userId')
-        break
-      case 'interested':
-        filterTasks('assigned')
-        break
-      case 'supported':
-        filterTasks('supported')
-        break
-      default:
-        filterTasks('userId')
-        break
-    }
-  }
+  const userId = user?.data?.id
+
+  const fetchIssues = useCallback(
+    (pageOverride?: number, rowsOverride?: number, sortOverride?: typeof currentSort, filterOverride?: string) => {
+      if (!userId) return
+      const activePage = pageOverride ?? page
+      const activeRows = rowsOverride ?? rowsPerPage
+      const activeSort = sortOverride ?? currentSort
+      const activeFilter = filterOverride ?? filter
+      const paramKey = TAB_TO_PARAM[activeFilter] ?? 'userId'
+      listTasks({
+        projectId: project_id,
+        [paramKey]: userId,
+        page: activePage,
+        limit: activeRows,
+        ...(activeSort.sortBy ? activeSort : {})
+      })
+    },
+    [userId, filter, page, rowsPerPage, currentSort, listTasks, project_id]
+  )
 
   useEffect(() => {
     fetchProject(project_id)
   }, [project_id])
 
   useEffect(() => {
-    listTasks({ projectId: project_id })
-  }, [project_id])
+    if (userId) {
+      setPage(0)
+      fetchIssues(0, rowsPerPage, {})
+    }
+  }, [userId, project_id])
 
   useEffect(() => {
-    getFilteredIssues(filter)
+    if (userId) {
+      setPage(0)
+      setCurrentSort({})
+      fetchIssues(0, rowsPerPage, {}, filter)
+    }
   }, [filter])
 
-  return <MyProjectIssuesPrivatePage project={project} user={user} issues={issues} />
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      setPage(newPage)
+      fetchIssues(newPage, rowsPerPage, currentSort)
+    },
+    [fetchIssues, rowsPerPage, currentSort]
+  )
+
+  const handleRowsPerPageChange = useCallback(
+    (newRowsPerPage: number) => {
+      setRowsPerPage(newRowsPerPage)
+      setPage(0)
+      fetchIssues(0, newRowsPerPage, currentSort)
+    },
+    [fetchIssues, currentSort]
+  )
+
+  const handleSortChange = useCallback(
+    (sortBy: string, sortDirection: 'asc' | 'desc' | 'none') => {
+      const newSort = sortDirection === 'none' ? {} : { sortBy, sortDirection }
+      setCurrentSort(newSort)
+      setPage(0)
+      fetchIssues(0, rowsPerPage, newSort)
+    },
+    [fetchIssues, rowsPerPage]
+  )
+
+  const serverSidePagination = {
+    enabled: true,
+    totalCount: issues.totalCount ?? 0,
+    page,
+    rowsPerPage,
+    onPageChange: handlePageChange,
+    onRowsPerPageChange: handleRowsPerPageChange,
+    onSortChange: handleSortChange
+  }
+
+  return (
+    <MyProjectIssuesPrivatePage
+      project={project}
+      user={user}
+      issues={issues}
+      serverSidePagination={serverSidePagination}
+    />
+  )
 }
 export default MyProjectIssuesPage

--- a/frontend/src/components/areas/private/features/issues/pages/user-organization-issues-explore-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/user-organization-issues-explore-page.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 import ExploreOrganizationPage from 'design-library/pages/private-pages/organization-pages/explore-organization-issues-private-page/explore-organization-issues-private-page'
 import { useParams } from 'react-router-dom'
 
+const DEFAULT_ROWS_PER_PAGE = 10
+
 const UserOrganizationIssuesExplorePage = ({
   filterTasks,
   listTasks,
@@ -25,7 +27,7 @@ const UserOrganizationIssuesExplorePage = ({
   }, [organization_id])
 
   useEffect(() => {
-    listTasksWithOrganization({ organizationId: organization_id })
+    listTasksWithOrganization({ page: 0, limit: DEFAULT_ROWS_PER_PAGE })
   }, [organization_id])
 
   return (
@@ -39,6 +41,7 @@ const UserOrganizationIssuesExplorePage = ({
       languages={languages}
       listLanguages={listLanguages}
       user={user}
+      defaultRowsPerPage={DEFAULT_ROWS_PER_PAGE}
     />
   )
 }

--- a/frontend/src/components/areas/private/features/issues/pages/user-project-issues-explore-page.tsx
+++ b/frontend/src/components/areas/private/features/issues/pages/user-project-issues-explore-page.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 import ExploreProjectPage from 'design-library/pages/private-pages/project-pages/explore-project-issues-private-page/explore-project-issues-private-page'
 import { useParams } from 'react-router-dom'
 
+const DEFAULT_ROWS_PER_PAGE = 10
+
 const UserProjectIssuesExplorePage = ({
   filterTasks,
   listTasks,
@@ -24,7 +26,7 @@ const UserProjectIssuesExplorePage = ({
   }, [project_id])
 
   useEffect(() => {
-    listTasksWithProject({ projectId: project_id })
+    listTasksWithProject({ page: 0, limit: DEFAULT_ROWS_PER_PAGE })
   }, [project_id])
 
   return (
@@ -37,6 +39,7 @@ const UserProjectIssuesExplorePage = ({
       listLabels={listLabels}
       languages={languages}
       listLanguages={listLanguages}
+      defaultRowsPerPage={DEFAULT_ROWS_PER_PAGE}
     />
   )
 }

--- a/frontend/src/components/design-library/molecules/tables/project-issue-table/project-issue-table.tsx
+++ b/frontend/src/components/design-library/molecules/tables/project-issue-table/project-issue-table.tsx
@@ -27,9 +27,54 @@ export const ProjectIssuesTable = ({
   languages,
   listLabels,
   listLanguages,
-  listTasks
+  listTasks,
+  serverSidePagination = false,
+  defaultRowsPerPage = 10
 }) => {
   const issueMetadata = useIssueMetadata({ includeProject: false })
+
+  const [page, setPage] = React.useState(0)
+  const [rowsPerPage, setRowsPerPage] = React.useState(defaultRowsPerPage)
+  const [currentFilters, setCurrentFilters] = React.useState<Record<string, any>>({})
+  const [currentSort, setCurrentSort] = React.useState<{ sortBy?: string; sortDirection?: string }>(
+    {}
+  )
+
+  const handleServerFilterChange = React.useCallback(
+    (filters: Record<string, any>) => {
+      setCurrentFilters(filters)
+      setPage(0)
+      listTasks({ ...filters, page: 0, limit: rowsPerPage, ...currentSort })
+    },
+    [listTasks, rowsPerPage, currentSort]
+  )
+
+  const handlePageChange = React.useCallback(
+    (newPage: number) => {
+      setPage(newPage)
+      listTasks({ ...currentFilters, page: newPage, limit: rowsPerPage, ...currentSort })
+    },
+    [listTasks, currentFilters, rowsPerPage, currentSort]
+  )
+
+  const handleRowsPerPageChange = React.useCallback(
+    (newRowsPerPage: number) => {
+      setRowsPerPage(newRowsPerPage)
+      setPage(0)
+      listTasks({ ...currentFilters, page: 0, limit: newRowsPerPage, ...currentSort })
+    },
+    [listTasks, currentFilters, currentSort]
+  )
+
+  const handleSortChange = React.useCallback(
+    (sortBy: string, sortDirection: 'asc' | 'desc' | 'none') => {
+      const newSort = sortDirection === 'none' ? {} : { sortBy, sortDirection }
+      setCurrentSort(newSort)
+      setPage(0)
+      listTasks({ ...currentFilters, page: 0, limit: rowsPerPage, ...newSort })
+    },
+    [listTasks, currentFilters, rowsPerPage]
+  )
 
   return (
     <>
@@ -38,14 +83,29 @@ export const ProjectIssuesTable = ({
         languages={languages}
         listLabels={listLabels}
         listLanguages={listLanguages}
-        listTasks={listTasks}
+        listTasks={serverSidePagination ? undefined : listTasks}
         filterTasks={filterTasks}
         issues={issues.data}
+        serverSideMode={serverSidePagination}
+        onServerFilterChange={serverSidePagination ? handleServerFilterChange : undefined}
       />
       <SectionTable
         tableData={issues}
         tableHeaderMetadata={issueMetadata}
         customColumnRenderer={customColumnRenderer}
+        serverSidePagination={
+          serverSidePagination
+            ? {
+                enabled: true,
+                totalCount: issues.totalCount ?? 0,
+                page,
+                rowsPerPage,
+                onPageChange: handlePageChange,
+                onRowsPerPageChange: handleRowsPerPageChange,
+                onSortChange: handleSortChange
+              }
+            : undefined
+        }
       />
     </>
   )

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
@@ -52,22 +52,24 @@ const SectionTable = ({
   serverSidePagination
 }: SectionTableProps) => {
   const isServerSide = !!serverSidePagination?.enabled
+  const safeData = Array.isArray(tableData?.data) ? tableData.data : []
 
   // Internal state — only active in client-side mode
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(10)
   const [sortedBy, setSortedBy] = useState(null)
   const [sortDirection, setSortDirection] = useState('asc')
-  const [sortedData, setSortedData] = useState(tableData.data)
+  const [sortedData, setSortedData] = useState(safeData)
 
   // Keep last completed rows so pagination shows previous data dimmed
   // instead of collapsing to skeletons between pages.
-  const previousRowsRef = useRef<any[]>(tableData.data)
+  const previousRowsRef = useRef<any[]>(safeData)
   const [isTransitioning, setIsTransitioning] = useState(false)
 
   useEffect(() => {
+    const currentSafeData = Array.isArray(tableData?.data) ? tableData.data : []
     if (tableData.completed) {
-      previousRowsRef.current = tableData.data
+      previousRowsRef.current = currentSafeData
       setIsTransitioning(false)
     } else if (isServerSide && previousRowsRef.current.length > 0) {
       setIsTransitioning(true)
@@ -75,9 +77,10 @@ const SectionTable = ({
   }, [tableData.completed, isServerSide])
 
   useEffect(() => {
+    const currentSafeData = Array.isArray(tableData?.data) ? tableData.data : []
     const newSortedData = isServerSide
-      ? tableData.data
-      : sortData(tableData.data, sortedBy, sortDirection)
+      ? currentSafeData
+      : sortData(currentSafeData, sortedBy, sortDirection)
     setSortedData(newSortedData)
   }, [tableData, sortedBy, sortDirection])
 
@@ -154,7 +157,7 @@ const SectionTable = ({
   }
 
   const handleSort = (fieldId, sortDirection) => {
-    const newSortedData = sortData(tableData.data, fieldId, sortDirection)
+    const newSortedData = sortData(Array.isArray(tableData?.data) ? tableData.data : [], fieldId, sortDirection)
     setSortedBy(fieldId)
     setSortDirection(sortDirection)
     setSortedData(newSortedData)
@@ -250,7 +253,7 @@ const SectionTable = ({
     </TableHead>
   )
 
-  if (tableData.completed && tableData.data.length === 0) {
+  if (tableData.completed && safeData.length === 0) {
     return (
       <RootPaper sx={{ p: 2 }}>
         <EmptyBase

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
@@ -22,6 +22,7 @@ type MetaDataProps = {
   numeric?: boolean
   dataBaseKey?: string
   serverSortKey?: string
+  sortable?: boolean
   label: string
   minWidth?: number
   width?: number
@@ -178,9 +179,9 @@ const SectionTable = ({
               : 'asc'
           : 'asc'
 
-      if (isServerSide) {
+      if (isServerSide && serverSortKey) {
         setSortDirection(newSortDirection)
-        serverSidePagination.onSortChange?.(serverSortKey ?? fieldId, newSortDirection as any)
+        serverSidePagination.onSortChange?.(serverSortKey, newSortDirection as any)
       } else {
         handleSort(fieldId, newSortDirection)
       }
@@ -228,7 +229,7 @@ const SectionTable = ({
   const paginationCount = isServerSide ? (serverSidePagination.totalCount ?? 0) : sortedData.length
 
   const TableCellWithSortLogic = ({ fieldId, metadata, sortHandler }) => {
-    const isSortable = isServerSide ? !!metadata.serverSortKey : !!metadata.sortable
+    const isSortable = !!metadata.serverSortKey || !!metadata.sortable
     return (
       <TableSortLabel
         active={isSortable && fieldId === sortedBy && sortDirection !== 'none'}

--- a/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
+++ b/frontend/src/components/design-library/molecules/tables/section-table/section-table.tsx
@@ -157,7 +157,11 @@ const SectionTable = ({
   }
 
   const handleSort = (fieldId, sortDirection) => {
-    const newSortedData = sortData(Array.isArray(tableData?.data) ? tableData.data : [], fieldId, sortDirection)
+    const newSortedData = sortData(
+      Array.isArray(tableData?.data) ? tableData.data : [],
+      fieldId,
+      sortDirection
+    )
     setSortedBy(fieldId)
     setSortDirection(sortDirection)
     setSortedData(newSortedData)

--- a/frontend/src/components/design-library/pages/private-pages/organization-pages/explore-organization-issues-private-page/explore-organization-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/organization-pages/explore-organization-issues-private-page/explore-organization-issues-private-page.tsx
@@ -18,7 +18,8 @@ const ExploreOrganizationIssuesPrivatePage = ({
   listLabels,
   languages,
   listLanguages,
-  user
+  user,
+  defaultRowsPerPage
 }) => {
   const { data, completed } = organization
   const projectList = { data: data?.Projects || [], completed }
@@ -74,6 +75,8 @@ const ExploreOrganizationIssuesPrivatePage = ({
             listLabels={listLabels}
             listLanguages={listLanguages}
             listTasks={listTasks}
+            serverSidePagination={true}
+            defaultRowsPerPage={defaultRowsPerPage}
           />
         </TopSection>
       </Container>

--- a/frontend/src/components/design-library/pages/private-pages/organization-pages/my-organization-issues-private-page/my-organization-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/organization-pages/my-organization-issues-private-page/my-organization-issues-private-page.tsx
@@ -75,7 +75,11 @@ const MyOrganizationIssuesPrivatePage = ({ organization, user, issues, serverSid
           <ProjectListCompact projects={projectList} />
         </TopSection>
         <TopSection>
-          <TabbedTable tabs={currentTabs} activeTab={activeTab} serverSidePagination={serverSidePagination} />
+          <TabbedTable
+            tabs={currentTabs}
+            activeTab={activeTab}
+            serverSidePagination={serverSidePagination}
+          />
         </TopSection>
       </Container>
     </ExplorePaper>

--- a/frontend/src/components/design-library/pages/private-pages/organization-pages/my-organization-issues-private-page/my-organization-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/organization-pages/my-organization-issues-private-page/my-organization-issues-private-page.tsx
@@ -14,7 +14,7 @@ import ContextTitle from 'design-library/atoms/typography/context-title/context-
 import ProjectListCompact from 'design-library/molecules/lists/project-list/project-list-compact/project-list-compact'
 import useMyIssueTabs from '../../../../../../hooks/use-my-issues-tabs'
 
-const MyOrganizationIssuesPrivatePage = ({ organization, user, issues }) => {
+const MyOrganizationIssuesPrivatePage = ({ organization, user, issues, serverSidePagination }) => {
   const { organization_id } = useParams<{ organization_id: string }>()
   const issueMetadata = useIssueMetadata({ includeProject: true })
 
@@ -75,7 +75,7 @@ const MyOrganizationIssuesPrivatePage = ({ organization, user, issues }) => {
           <ProjectListCompact projects={projectList} />
         </TopSection>
         <TopSection>
-          <TabbedTable tabs={currentTabs} activeTab={activeTab} />
+          <TabbedTable tabs={currentTabs} activeTab={activeTab} serverSidePagination={serverSidePagination} />
         </TopSection>
       </Container>
     </ExplorePaper>

--- a/frontend/src/components/design-library/pages/private-pages/project-pages/explore-project-issues-private-page/explore-project-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/project-pages/explore-project-issues-private-page/explore-project-issues-private-page.tsx
@@ -16,7 +16,8 @@ const ExploreProjectPage = ({
   labels,
   listLabels,
   languages,
-  listLanguages
+  listLanguages,
+  defaultRowsPerPage
 }) => {
   return (
     <ExplorePaper elevation={0}>
@@ -63,6 +64,8 @@ const ExploreProjectPage = ({
             listLabels={listLabels}
             listLanguages={listLanguages}
             listTasks={listTasks}
+            serverSidePagination={true}
+            defaultRowsPerPage={defaultRowsPerPage}
           />
         </TopSection>
       </Container>

--- a/frontend/src/components/design-library/pages/private-pages/project-pages/my-project-issues-private-page/my-project-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/project-pages/my-project-issues-private-page/my-project-issues-private-page.tsx
@@ -13,7 +13,7 @@ import MainTitle from 'design-library/atoms/typography/main-title/main-title'
 import ContextTitle from 'design-library/atoms/typography/context-title/context-title'
 import useMyIssueTabs from '../../../../../../hooks/use-my-issues-tabs'
 
-const MyProjectIssuesPrivatePage = ({ project, user, issues }) => {
+const MyProjectIssuesPrivatePage = ({ project, user, issues, serverSidePagination }) => {
   const { project_id, organization_id } = useParams<{
     project_id: string
     organization_id: string
@@ -72,7 +72,7 @@ const MyProjectIssuesPrivatePage = ({ project, user, issues }) => {
           />
         </TopSection>
         <TopSection>
-          <TabbedTable tabs={currentTabs} activeTab={activeTab} />
+          <TabbedTable tabs={currentTabs} activeTab={activeTab} serverSidePagination={serverSidePagination} />
         </TopSection>
       </Container>
     </ExplorePaper>

--- a/frontend/src/components/design-library/pages/private-pages/project-pages/my-project-issues-private-page/my-project-issues-private-page.tsx
+++ b/frontend/src/components/design-library/pages/private-pages/project-pages/my-project-issues-private-page/my-project-issues-private-page.tsx
@@ -72,7 +72,11 @@ const MyProjectIssuesPrivatePage = ({ project, user, issues, serverSidePaginatio
           />
         </TopSection>
         <TopSection>
-          <TabbedTable tabs={currentTabs} activeTab={activeTab} serverSidePagination={serverSidePagination} />
+          <TabbedTable
+            tabs={currentTabs}
+            activeTab={activeTab}
+            serverSidePagination={serverSidePagination}
+          />
         </TopSection>
       </Container>
     </ExplorePaper>

--- a/frontend/src/containers/profile/profile-my-organization-issues.ts
+++ b/frontend/src/containers/profile/profile-my-organization-issues.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-console */
 import { connect } from 'react-redux'
 import MyOrganizationIssuesPage from '../../components/areas/private/features/issues/pages/my-organization-issues-page'
-import { listTasks, filterTasks } from '../../actions/taskActions'
+import { listTasks } from '../../actions/taskActions'
 import { fetchOrganization } from '../../actions/organizationsActions'
 import { listLabels } from '../../actions/labelActions'
 import { listLanguage } from '../../actions/languageActions'
-import { getFilteredTasks, getOrganization } from '../../selectors/tasks'
+import { getOrganization } from '../../selectors/tasks'
 import { getCurrentUser } from '../../common/selectors/user/getUser'
 
 const mapStateToProps = (state: any, props: any) => {
   return {
     user: getCurrentUser(state),
-    issues: getFilteredTasks(state),
+    issues: state.tasks,
     organization: getOrganization(state),
     labels: state.labels,
     languages: state.languages
@@ -21,8 +21,6 @@ const mapStateToProps = (state: any, props: any) => {
 const mapDispatchToProps = (dispatch: any, ownProps: any) => {
   return {
     listTasks: (params: any) => dispatch(listTasks(params)),
-    filterTasks: (key: any, value: any, additional: any) =>
-      dispatch(filterTasks(key, value, additional)),
     fetchOrganization: (organizationId: any) => dispatch(fetchOrganization(organizationId)),
     listLabels: () => dispatch(listLabels()),
     listLanguages: () => dispatch(listLanguage())

--- a/frontend/src/containers/profile/profile-my-project-issues.ts
+++ b/frontend/src/containers/profile/profile-my-project-issues.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-console */
 import { connect } from 'react-redux'
 import UserMyProjectIssuesPage from '../../components/areas/private/features/issues/pages/my-project-issues-page'
-import { listTasks, filterTasks } from '../../actions/taskActions'
+import { listTasks } from '../../actions/taskActions'
 import { fetchProject, listProjects } from '../../actions/projectActions'
 import { listLabels } from '../../actions/labelActions'
 import { listLanguage } from '../../actions/languageActions'
-import { getFilteredTasks, getProject } from '../../selectors/tasks'
+import { getProject } from '../../selectors/tasks'
 import { getCurrentUser } from '../../common/selectors/user/getUser'
 
 const mapStateToProps = (state: any, props: any) => {
   return {
     user: getCurrentUser(state),
-    issues: getFilteredTasks(state),
+    issues: state.tasks,
     project: getProject(state),
     labels: state.labels,
     languages: state.languages
@@ -21,8 +21,6 @@ const mapStateToProps = (state: any, props: any) => {
 const mapDispatchToProps = (dispatch: any, ownProps: any) => {
   return {
     listTasks: (params: any) => dispatch(listTasks(params)),
-    filterTasks: (key: any, value: any, additional: any) =>
-      dispatch(filterTasks(key, value, additional)),
     fetchProject: (projectId: any, params: any) => dispatch(fetchProject(projectId, params)),
     listProjects: () => dispatch(listProjects()),
     listLabels: () => dispatch(listLabels()),

--- a/frontend/src/reducers/taskReducer.js
+++ b/frontend/src/reducers/taskReducer.js
@@ -197,7 +197,7 @@ export const tasks = (
     case FETCH_PROJECT_REQUESTED:
       return { ...state, completed: action.completed }
     case FETCH_PROJECT_SUCCESS:
-      return { ...state, completed: action.completed, data: action.data.Tasks }
+      return { ...state, completed: action.completed, data: action.data.Tasks || [] }
     case FETCH_PROJECT_ERROR:
       return { ...state, completed: action.completed, error: action.error }
     case FILTER_TASK_REQUESTED:


### PR DESCRIPTION
This pull request introduces server-side pagination and sorting for issues tables in both organization and project contexts, improving scalability and performance when handling large datasets. The changes refactor how issues are fetched, moving pagination, filtering, and sorting logic to the server, and propagate these enhancements through the relevant components. Additionally, the code ensures robustness by handling edge cases in data rendering.

Key changes include:

**Server-side Pagination & Sorting Implementation:**

* Added server-side pagination, sorting, and filtering logic to `my-organization-issues-page.tsx` and `my-project-issues-page.tsx`, including state management for page, rows per page, and sort order, and passing the new `serverSidePagination` prop to child components. [[1]](diffhunk://#diff-8e2eac289e314b2274da2fa56681a028d41500de42d0fa077a6eb415b9733d55L1-R111) [[2]](diffhunk://#diff-a1e0e3a247eba0e36cf510ae13c3817faf41faee2287282457d317c46583d794L1-R112)
* Refactored `ProjectIssuesTable` to handle server-side pagination, sort, and filter changes, and to accept `serverSidePagination` and `defaultRowsPerPage` as props, delegating data fetching to the parent when enabled.
* Updated `SectionTable` to safely handle missing or malformed data arrays and to support server-side mode, including correct rendering and sorting behavior. [[1]](diffhunk://#diff-8498da36c6b87d30b0879739e9b024cc745aba6ad1c7cff2d021420ae54f69b0R55-R83) [[2]](diffhunk://#diff-8498da36c6b87d30b0879739e9b024cc745aba6ad1c7cff2d021420ae54f69b0L157-R164) [[3]](diffhunk://#diff-8498da36c6b87d30b0879739e9b024cc745aba6ad1c7cff2d021420ae54f69b0L253-R260)

**Integration with Explore and Private Pages:**

* Updated organization and project "explore" pages (`user-organization-issues-explore-page.tsx`, `user-project-issues-explore-page.tsx`, `explore-organization-issues-private-page.tsx`, `explore-project-issues-private-page.tsx`) to use a consistent `DEFAULT_ROWS_PER_PAGE`, pass it as a prop, and initialize server-side pagination. [[1]](diffhunk://#diff-0a02350dc6ddb8f7f9f838e5177cac482c531753873690f5b96cf5242fd30e3dR5-R6) [[2]](diffhunk://#diff-0a02350dc6ddb8f7f9f838e5177cac482c531753873690f5b96cf5242fd30e3dL28-R30) [[3]](diffhunk://#diff-0a02350dc6ddb8f7f9f838e5177cac482c531753873690f5b96cf5242fd30e3dR44) [[4]](diffhunk://#diff-4e3508c0e57516a0065fd25d51322e90daa43a8ff3e2fa4aa94c6484691cf36aR5-R6) [[5]](diffhunk://#diff-4e3508c0e57516a0065fd25d51322e90daa43a8ff3e2fa4aa94c6484691cf36aL27-R29) [[6]](diffhunk://#diff-4e3508c0e57516a0065fd25d51322e90daa43a8ff3e2fa4aa94c6484691cf36aR42) [[7]](diffhunk://#diff-489d61f643dde750bd98220ea8cc2f212e3b0d468d09c995a1939802788094daL21-R22) [[8]](diffhunk://#diff-489d61f643dde750bd98220ea8cc2f212e3b0d468d09c995a1939802788094daR78-R79) [[9]](diffhunk://#diff-d2d31df337fd5f199359c818c267db733cfcff90438f143e21a9715aa4302054L19-R20) [[10]](diffhunk://#diff-d2d31df337fd5f199359c818c267db733cfcff90438f143e21a9715aa4302054R67-R68)

**Component Propagation and Tabbed Table Updates:**

* Modified `MyOrganizationIssuesPrivatePage` and `MyProjectIssuesPrivatePage` to accept and propagate the `serverSidePagination` prop to their respective tabbed tables, ensuring consistent pagination behavior across tabs. [[1]](diffhunk://#diff-ad1e8920a6ed715b9cdf30ca77001d007c256bdeadbf95c6629c94190ea7f9d5L17-R17) [[2]](diffhunk://#diff-ad1e8920a6ed715b9cdf30ca77001d007c256bdeadbf95c6629c94190ea7f9d5L78-R82) [[3]](diffhunk://#diff-47a8b1631b10903ddf44f38e32e1fe17dcc119d919a1bb9cf8b451c47238430cL16-R16)

These enhancements collectively enable efficient, scalable issue browsing with improved user experience on large datasets.