### PR TITLE
Fix Whop bounty checkout failing with "Title is too long" error

### DIFF
--- a/src/modules/orders/orderBuilds.ts
+++ b/src/modules/orders/orderBuilds.ts
@@ -171,8 +171,8 @@ export async function orderBuilds(orderParameters: OrderBuildsParams) {
     const bountyTitle =
       (taskTitle && String(taskTitle).trim()) || `Gitpay bounty #${orderCreated.dataValues.id}`
     const bountyDescription = taskTitle
-      ? `Bounty for: ${taskTitle}`
-      : `Gitpay bounty order ${orderCreated.dataValues.id}`
+      ? `Bounty for: ${taskTitle} (${taskUrl})`
+      : `Gitpay bounty order ${orderCreated.dataValues.id} (${taskUrl})`
 
     const checkout = await paymentProvider.createBountyCheckout({
       amount: totalPrice,

--- a/src/providers/whop/WhopPaymentProvider.ts
+++ b/src/providers/whop/WhopPaymentProvider.ts
@@ -86,6 +86,8 @@ export class WhopPaymentProvider implements PaymentProvider {
     }
 
     const productTitle = (params.title || params.description || 'Gitpay bounty').trim().slice(0, 80)
+    // Whop plan titles (unlike product titles, which allow 80) are capped at 30 chars.
+    const planTitle = productTitle.slice(0, 30)
 
     const product = await this.client.post<any>('/products', {
       title: productTitle,
@@ -106,7 +108,7 @@ export class WhopPaymentProvider implements PaymentProvider {
         initial_price: params.amount,
         plan_type: 'one_time',
         currency: params.currency || 'usd',
-        title: productTitle,
+        title: planTitle,
         description: params.description || productTitle,
         force_create_new_plan: true
       }

--- a/test/api/order/orderCreateWhop.test.ts
+++ b/test/api/order/orderCreateWhop.test.ts
@@ -90,6 +90,62 @@ describe('POST /orders (Whop)', () => {
       expect(productBody.company_id).to.equal('biz_test_platform')
       expect(checkoutBody.plan.product_id).to.equal('prod_bounty_1')
       expect(checkoutBody.plan.title).to.equal('Whop bounty task')
+      expect(checkoutBody.plan.description).to.include('Whop bounty task')
+    })
+  })
+
+  it('should truncate the Whop plan title to 30 characters for long issue titles', async () => {
+    await withPaymentProvider('whop', async () => {
+      pinWhopApiForTests()
+      let productBody: any
+      let checkoutBody: any
+
+      nock(WHOP_API_HOST)
+        .post('/api/v1/products', (body) => {
+          productBody = body
+          return true
+        })
+        .reply(200, { id: 'prod_bounty_2', title: 'Multi-language support / internationalize' })
+
+      nock(WHOP_API_HOST)
+        .post('/api/v1/checkout_configurations', (body) => {
+          checkoutBody = body
+          return true
+        })
+        .reply(200, checkoutConfig)
+
+      const user = await registerAndLogin(agent)
+      const longTitle =
+        'Multi-language support / internationalize descriptions and display-values'
+      const task = await TaskFactory({
+        url: 'https://github.com/test/repo/issues/11',
+        userId: user.body.id,
+        title: longTitle
+      })
+
+      await agent
+        .post('/orders')
+        .send({
+          currency: 'usd',
+          amount: 100,
+          email: 'funder@gitpay.me',
+          userId: user.body.id,
+          taskId: task.id,
+          plan: 'open source',
+          provider: 'whop'
+        })
+        .set('Authorization', user.headers.authorization)
+        .expect(200)
+
+      // Product title allows up to 80 chars and keeps the full issue title.
+      expect(productBody.title).to.equal(longTitle)
+      // Plan title must respect Whop's 30-char limit, which caused the "Title is
+      // too long (maximum is 30 characters)" production error before this fix.
+      expect(checkoutBody.plan.title.length).to.be.at.most(30)
+      expect(checkoutBody.plan.title).to.equal(longTitle.slice(0, 30))
+      // The full issue title and a link back to it must still be reachable via description.
+      expect(checkoutBody.plan.description).to.include(longTitle)
+      expect(checkoutBody.plan.description).to.include('/task/')
     })
   })
 


### PR DESCRIPTION
Whop plan titles are capped at 30 characters, but createBountyCheckout
reused the 80-char product title verbatim as the plan title, so any
issue title over 30 chars (e.g. long GitHub issue titles) caused
Whop's /checkout_configurations call to reject the order with
"Validation failed: Title is too long (maximum is 30 characters)" in
production.

Truncate the plan title to 30 chars separately from the 80-char
product title, mirroring the existing pattern in
createCheckoutForAmount. Also thread the Gitpay task URL into the
bounty description so the full issue title/reference stays reachable
even once the plan title is truncated.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTwvkPKSAQqNFBDwbihSs9