### PR TITLE
Fix checkout amount rounding $21.60 up to $22 on Whop and other providers

### DIFF
--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -100,7 +100,7 @@ export default class Plan
       full: 1.3,
       'with support': 1.3
     }
-    return Math.round(Number((price * percentages[plan || 'open source']).toFixed(2)))
+    return Math.round(price * percentages[plan || 'open source'] * 100) / 100
   }
 
   finalPrice(): number {

--- a/test/api/order/orderCreateWhop.test.ts
+++ b/test/api/order/orderCreateWhop.test.ts
@@ -94,6 +94,48 @@ describe('POST /orders (Whop)', () => {
     })
   })
 
+  it('should pass the exact fee-inclusive amount to Whop without rounding to a whole dollar', async () => {
+    await withPaymentProvider('whop', async () => {
+      pinWhopApiForTests()
+      let checkoutBody: any
+
+      nock(WHOP_API_HOST)
+        .post('/api/v1/products')
+        .reply(200, { id: 'prod_bounty_3', title: 'Whop exact amount bounty' })
+
+      nock(WHOP_API_HOST)
+        .post('/api/v1/checkout_configurations', (body) => {
+          checkoutBody = body
+          return true
+        })
+        .reply(200, checkoutConfig)
+
+      const user = await registerAndLogin(agent)
+      const task = await TaskFactory({
+        url: 'https://github.com/test/repo/issues/12',
+        userId: user.body.id,
+        title: 'Whop exact amount bounty'
+      })
+
+      await agent
+        .post('/orders')
+        .send({
+          currency: 'usd',
+          amount: 20,
+          email: 'funder@gitpay.me',
+          userId: user.body.id,
+          taskId: task.id,
+          plan: 'open source',
+          provider: 'whop'
+        })
+        .set('Authorization', user.headers.authorization)
+        .expect(200)
+
+      // 20 + 8% open source fee = 21.6, must reach Whop as 21.6, not rounded to 22.
+      expect(checkoutBody.plan.initial_price).to.equal(21.6)
+    })
+  })
+
   it('should truncate the Whop plan title to 30 characters for long issue titles', async () => {
     await withPaymentProvider('whop', async () => {
       pinWhopApiForTests()

--- a/test/models/plan.test.ts
+++ b/test/models/plan.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import Models from '../../src/models'
+
+const models = Models as any
+
+describe('Plan.calcFinalPrice', () => {
+  it('should keep the exact fee-inclusive cents amount instead of rounding to a whole dollar', () => {
+    // 20 + 8% open source fee = 21.6, previously rounded up to 22.
+    expect(models.Plan.calcFinalPrice(20, 'open source')).to.equal(21.6)
+  })
+
+  it('should preserve cents for a private plan', () => {
+    // 20 + 18% private fee = 23.6
+    expect(models.Plan.calcFinalPrice(20, 'private')).to.equal(23.6)
+  })
+
+  it('should preserve cents for a full/with-support plan', () => {
+    // 20 + 30% fee = 26
+    expect(models.Plan.calcFinalPrice(20, 'full')).to.equal(26)
+  })
+
+  it('should charge no fee for open source amounts of 5000 or more', () => {
+    expect(models.Plan.calcFinalPrice(5000, 'open source')).to.equal(5000)
+  })
+
+  it('should default to the open source fee when no plan is given', () => {
+    expect(models.Plan.calcFinalPrice(20)).to.equal(21.6)
+  })
+})


### PR DESCRIPTION
Plan.calcFinalPrice correctly computed the fee-inclusive price to the
cent via toFixed(2), but then rounded that dollar value to the nearest
whole dollar with an outer Math.round(...), so a $20 bounty with the
8% open source fee ($21.60) was sent to Whop's checkout as $22.

This shared function feeds Whop's bounty checkout (initial_price),
PayPal order creation/updates, and Stripe's classic charge path, so
the fix (round to cents, not whole dollars) applies consistently
across all three providers.

Claude-Session: https://claude.ai/code/session_018Rdteo43Vj6djnjq4528yV