### PR TITLE
Fix mobile side-menu label overlapping GITPAY logo

### DIFF
--- a/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.tsx
+++ b/frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.tsx
@@ -85,7 +85,11 @@ export const LeftSide = styled(Side)<{ isActive: boolean }>(({ isActive }) => ({
   }),
   '@media (max-width: 37.5em)': {
     alignItems: 'flex-start',
-    justifyContent: 'flex-start'
+    justifyContent: 'flex-start',
+    ...(!isActive && {
+      position: 'relative' as const,
+      zIndex: 1300
+    })
   }
 }))
 
@@ -97,16 +101,16 @@ export const RightSide = styled(Side)<{ isActive: boolean }>(({ isActive }) => (
     top: 0,
     right: 0,
     backgroundColor: '#2c5c46',
-    height: '100vh',
+    height: '100dvh',
     width: '100vw',
     justifyContent: 'center',
     alignItems: 'center',
     transform: 'translateY(-100%)',
     transition: 'all ease-in-out 400ms',
     zIndex: 1200,
+    overflow: 'hidden',
     ...(isActive && {
-      transform: 'translateY(0)',
-      overflow: 'hidden'
+      transform: 'translateY(0)'
     })
   }
 }))


### PR DESCRIPTION
## Summary

Fixes #1538.

On mobile viewports (≤ 600px), when the hamburger side-menu was closed, the currently-selected menu item's label (e.g. "My Payouts" on `/profile/payouts`) could bleed through and overlap the GITPAY logo in the top green header bar.

## Root cause

In `frontend/src/components/design-library/molecules/menus/side-menu/side-menu.styled.div.tsx`:

- `RightSide` (the mobile menu overlay wrapping the selected label) is `position: fixed`, `100vw` × `100vh`, `zIndex: 1200`, pushed off-screen via `transform: translateY(-100%)` when closed — but its content stays mounted, and `overflow: hidden` was only applied while the menu was **open**. On mobile browsers where the visual viewport differs from `100vh` (address bar show/hide), the translate offset can fail to fully clear the overlay, letting a sliver of the centered label bleed into view.
- `LeftSide` (logo + hamburger) only received a `zIndex` (1300) while the menu was **open**; in its default/closed state it had no explicit stacking context, so `RightSide`'s `zIndex: 1200` could render above it.

## Fix

- `RightSide`: always clip `overflow: hidden` on mobile (not just while open), and use `100dvh` instead of `100vh` so the overlay's height accounts for dynamic mobile browser chrome.
- `LeftSide`: give it `position: relative` + `zIndex: 1300` in its closed state too (the existing open-state override, which uses `position: fixed`, is preserved via an `!isActive` guard so opening the menu behaves exactly as before).

CSS-only change, no behavior/logic changes.

## Test plan

- [x] `npm run lint` / `tsc --noEmit` on the changed file — clean, no new errors or warnings.
- [x] Verified via Storybook (`Design Library/Molecules/Menus/SideMenu`) at a 375×667 mobile viewport with Playwright:
  - Closed state: computed styles confirm `LeftSide` now has `position: relative; z-index: 1300` and `RightSide` has `overflow: hidden`, header shows only the logo and hamburger with no label bleed.
  - Open state: confirmed unchanged — `LeftSide` still switches to `position: fixed; z-index: 1300`, menu overlay opens/closes correctly.
- [x] Manual check on a real mobile device/browser recommended before merge, since the original bug was viewport-chrome-dependent and hard to fully reproduce in a headless browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)