### PR TITLE
fix(auth): strip credentials from public task fetch

### DIFF
--- a/src/app/controllers/user/user.ts
+++ b/src/app/controllers/user/user.ts
@@ -8,7 +8,6 @@ import * as task from '../../../modules/tasks'
 import Sendmail from '../../../mail/mail'
 import UserMail from '../../../mail/user'
 import i18n from 'i18n'
-import { stripUserSecrets } from '../../../utils/auth/strip-user-secrets'
 
 const models = Models as any
 
@@ -27,7 +26,7 @@ export const updateUser = (req: any, res: any) => {
   req.body.id = req.user.id
   userUpdate(req.body)
     .then((data) => {
-      res.send(stripUserSecrets(data))
+      res.send(data)
     })
     .catch((error) => {
       const message =
@@ -50,7 +49,7 @@ export const register = async (req: any, res: any) => {
     }
     try {
       const data = await user.userBuilds(req.body)
-      res.send(stripUserSecrets(data))
+      res.send(data)
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.log(error)
@@ -220,7 +219,7 @@ export const activateUser = async (req: any, res: any) => {
     if (foundUser.dataValues.email_verified) {
       // eslint-disable-next-line no-console
       console.log(`[activation] activate no-op: user ${userId} already verified`)
-      res.send(stripUserSecrets(foundUser))
+      res.send(foundUser)
       return
     }
 
@@ -252,7 +251,7 @@ export const activateUser = async (req: any, res: any) => {
     )
     // eslint-disable-next-line no-console
     console.log(`[activation] activate success for user ${userId}`)
-    res.send(stripUserSecrets(userUpdate[1]))
+    res.send(userUpdate[1])
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.log('[activation] activate error', error)

--- a/src/app/controllers/user/user.ts
+++ b/src/app/controllers/user/user.ts
@@ -8,6 +8,7 @@ import * as task from '../../../modules/tasks'
 import Sendmail from '../../../mail/mail'
 import UserMail from '../../../mail/user'
 import i18n from 'i18n'
+import { stripUserSecrets } from '../../../utils/auth/strip-user-secrets'
 
 const models = Models as any
 
@@ -26,7 +27,7 @@ export const updateUser = (req: any, res: any) => {
   req.body.id = req.user.id
   userUpdate(req.body)
     .then((data) => {
-      res.send(data)
+      res.send(stripUserSecrets(data))
     })
     .catch((error) => {
       const message =
@@ -49,7 +50,7 @@ export const register = async (req: any, res: any) => {
     }
     try {
       const data = await user.userBuilds(req.body)
-      res.send(data)
+      res.send(stripUserSecrets(data))
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.log(error)
@@ -219,7 +220,7 @@ export const activateUser = async (req: any, res: any) => {
     if (foundUser.dataValues.email_verified) {
       // eslint-disable-next-line no-console
       console.log(`[activation] activate no-op: user ${userId} already verified`)
-      res.send(foundUser)
+      res.send(stripUserSecrets(foundUser))
       return
     }
 
@@ -251,7 +252,7 @@ export const activateUser = async (req: any, res: any) => {
     )
     // eslint-disable-next-line no-console
     console.log(`[activation] activate success for user ${userId}`)
-    res.send(userUpdate[1])
+    res.send(stripUserSecrets(userUpdate[1]))
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.log('[activation] activate error', error)

--- a/src/modules/tasks/taskFetch.ts
+++ b/src/modules/tasks/taskFetch.ts
@@ -6,10 +6,9 @@ import { roleExists } from '../roles'
 import { userExists } from '../users'
 // @ts-ignore - ip has no type definitions
 import { memberExists } from '../members'
-import { publicUserInclude, stripUserSecrets } from '../../utils/auth/strip-user-secrets'
+import { stripUserSecrets } from '../../utils/auth/strip-user-secrets'
 
 const currentModels = models as any
-const userInclude = publicUserInclude(currentModels.User)
 
 export async function taskFetch(taskParams: any) {
   const data = await currentModels.Task.findOne({
@@ -17,26 +16,29 @@ export async function taskFetch(taskParams: any) {
       id: taskParams.id
     },
     include: [
-      userInclude,
+      {
+        model: currentModels.User,
+        attributes: { exclude: ['password'] }
+      },
       {
         model: currentModels.Project,
         include: [currentModels.Organization]
       },
       {
         model: currentModels.Order,
-        include: [userInclude]
+        include: [currentModels.User]
       },
       {
         model: currentModels.Assign,
-        include: [userInclude]
+        include: [currentModels.User]
       },
       {
         model: currentModels.Member,
-        include: [userInclude, currentModels.Role]
+        include: [currentModels.User, currentModels.Role]
       },
       {
         model: currentModels.Offer,
-        include: [userInclude, currentModels.Task],
+        include: [currentModels.User, currentModels.Task],
         order: [['createdAt', 'ASC']]
       },
       {
@@ -81,7 +83,7 @@ export async function taskFetch(taskParams: any) {
           where: {
             id: data.assigned
           },
-          include: [userInclude]
+          include: [currentModels.User]
         }).catch((e: any) => {})
 
         const role = await roleExists({ name: 'company_owner' })

--- a/src/modules/tasks/taskFetch.ts
+++ b/src/modules/tasks/taskFetch.ts
@@ -6,8 +6,10 @@ import { roleExists } from '../roles'
 import { userExists } from '../users'
 // @ts-ignore - ip has no type definitions
 import { memberExists } from '../members'
+import { publicUserInclude, stripUserSecrets } from '../../utils/auth/strip-user-secrets'
 
 const currentModels = models as any
+const userInclude = publicUserInclude(currentModels.User)
 
 export async function taskFetch(taskParams: any) {
   const data = await currentModels.Task.findOne({
@@ -15,29 +17,26 @@ export async function taskFetch(taskParams: any) {
       id: taskParams.id
     },
     include: [
-      {
-        model: currentModels.User,
-        attributes: { exclude: ['password'] }
-      },
+      userInclude,
       {
         model: currentModels.Project,
         include: [currentModels.Organization]
       },
       {
         model: currentModels.Order,
-        include: [currentModels.User]
+        include: [userInclude]
       },
       {
         model: currentModels.Assign,
-        include: [currentModels.User]
+        include: [userInclude]
       },
       {
         model: currentModels.Member,
-        include: [currentModels.User, currentModels.Role]
+        include: [userInclude, currentModels.Role]
       },
       {
         model: currentModels.Offer,
-        include: [currentModels.User, currentModels.Task],
+        include: [userInclude, currentModels.Task],
         order: [['createdAt', 'ASC']]
       },
       {
@@ -64,7 +63,7 @@ export async function taskFetch(taskParams: any) {
   const projectName = splitIssueUrl[2]
   const issueId = splitIssueUrl[4]
 
-  if (data.dataValues.private) return data.dataValues
+  if (data.dataValues.private) return stripUserSecrets(data.dataValues)
 
   switch (data.dataValues.provider) {
     case 'github':
@@ -82,7 +81,7 @@ export async function taskFetch(taskParams: any) {
           where: {
             id: data.assigned
           },
-          include: [currentModels.User]
+          include: [userInclude]
         }).catch((e: any) => {})
 
         const role = await roleExists({ name: 'company_owner' })
@@ -226,13 +225,13 @@ export async function taskFetch(taskParams: any) {
             console.log('error', e)
           }
         }
-        return responseGithub
+        return stripUserSecrets(responseGithub)
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Github response error')
         // eslint-disable-next-line no-console
         console.log(e)
-        return data.dataValues
+        return stripUserSecrets(data.dataValues)
       }
 
     case 'bitbucket':
@@ -296,16 +295,16 @@ export async function taskFetch(taskParams: any) {
 
             */
 
-        return responseBitbucket
+        return stripUserSecrets(responseBitbucket)
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Bitbucket response error')
         // eslint-disable-next-line no-console
         console.log(e)
-        return data.dataValues
+        return stripUserSecrets(data.dataValues)
       }
 
     default:
-      return data.dataValues
+      return stripUserSecrets(data.dataValues)
   }
 }

--- a/src/utils/auth/strip-user-secrets.ts
+++ b/src/utils/auth/strip-user-secrets.ts
@@ -1,0 +1,52 @@
+export const USER_SECRET_ATTRIBUTES = [
+  'password',
+  'recover_password_token',
+  'activation_token',
+  'email_change_token',
+  'paypal_id',
+  'customer_id',
+  'account_id',
+  'whop_account_id',
+  'pending_email_change'
+] as const
+
+const SECRET_KEYS = new Set<string>(USER_SECRET_ATTRIBUTES)
+
+export const publicUserInclude = (UserModel: unknown) => ({
+  model: UserModel,
+  attributes: { exclude: [...USER_SECRET_ATTRIBUTES] }
+})
+
+const isSequelizeInstance = (value: unknown): value is { get: (options: { plain: boolean }) => unknown } => {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { get?: unknown }).get === 'function' &&
+    !!(value as { dataValues?: unknown }).dataValues
+  )
+}
+
+export function stripUserSecrets<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (value == null || typeof value !== 'object') return value
+  if (value instanceof Date) return value
+  if (seen.has(value as object)) return undefined as T
+  seen.add(value as object)
+
+  if (Array.isArray(value)) {
+    return value.map((item) => stripUserSecrets(item, seen)) as T
+  }
+
+  const source = isSequelizeInstance(value) ? value.get({ plain: true }) : value
+  if (source == null || typeof source !== 'object') return source as T
+
+  if (Array.isArray(source)) {
+    return source.map((item) => stripUserSecrets(item, seen)) as T
+  }
+
+  const out: Record<string, unknown> = {}
+  for (const [key, nested] of Object.entries(source as Record<string, unknown>)) {
+    if (SECRET_KEYS.has(key)) continue
+    out[key] = stripUserSecrets(nested, seen)
+  }
+  return out as T
+}

--- a/test/utils/auth/strip-user-secrets.test.ts
+++ b/test/utils/auth/strip-user-secrets.test.ts
@@ -85,6 +85,25 @@ describe('stripUserSecrets', () => {
     expect(stripUserSecrets(date)).to.equal(date)
   })
 
+  it('strips hashes and tokens from a register-style user payload', () => {
+    const registerBody = {
+      id: 8815,
+      email: 'user@example.com',
+      name: 'Leo',
+      password: '$2b$08$examplehash',
+      activation_token: 'a'.repeat(64),
+      recover_password_token: null,
+      paypal_id: null,
+      customer_id: null
+    }
+    const sanitized = stripUserSecrets(registerBody)
+    expect(sanitized).to.deep.equal({
+      id: 8815,
+      email: 'user@example.com',
+      name: 'Leo'
+    })
+  })
+
   it('plain-ifies sequelize-like instances before stripping', () => {
     const instance = {
       dataValues: {

--- a/test/utils/auth/strip-user-secrets.test.ts
+++ b/test/utils/auth/strip-user-secrets.test.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai'
+import {
+  USER_SECRET_ATTRIBUTES,
+  publicUserInclude,
+  stripUserSecrets
+} from '../../../src/utils/auth/strip-user-secrets'
+
+describe('stripUserSecrets', () => {
+  it('removes credential fields from a nested public task payload', () => {
+    const payload = {
+      id: 1224,
+      title: 'i18n',
+      User: {
+        id: 1,
+        name: 'Owner',
+        password: '$2b$08$not-a-real-hash',
+        paypal_id: 'secret@example.com',
+        customer_id: 'cus_secret'
+      },
+      orders: [
+        {
+          id: 10,
+          amount: '50',
+          User: {
+            id: 2,
+            name: 'Funder',
+            email: 'funder@example.com',
+            password: '$2b$08$also-not-real',
+            recover_password_token: 'reset-token',
+            activation_token: 'activate-token',
+            email_change_token: 'change-token',
+            paypal_id: 'paypal-secret',
+            customer_id: 'cus_funder',
+            account_id: 'acct_funder',
+            whop_account_id: 'whop_funder',
+            pending_email_change: 'new@example.com'
+          }
+        }
+      ],
+      Offers: [
+        {
+          id: 3,
+          User: {
+            id: 4,
+            username: 'solver',
+            password: 'hash'
+          }
+        }
+      ],
+      assignedUser: {
+        id: 5,
+        name: 'Assignee',
+        password: 'hash',
+        paypal_id: 'hidden'
+      }
+    }
+
+    const sanitized = stripUserSecrets(payload)
+
+    expect(sanitized.id).to.equal(1224)
+    expect(sanitized.User.name).to.equal('Owner')
+    expect(sanitized.User).to.not.have.property('password')
+    expect(sanitized.User).to.not.have.property('paypal_id')
+    expect(sanitized.User).to.not.have.property('customer_id')
+    expect(sanitized.orders[0].User.email).to.equal('funder@example.com')
+    expect(sanitized.orders[0].User.name).to.equal('Funder')
+    for (const key of USER_SECRET_ATTRIBUTES) {
+      expect(sanitized.orders[0].User).to.not.have.property(key)
+    }
+    expect(JSON.stringify(sanitized)).to.not.include('$2b$08$')
+    expect(JSON.stringify(sanitized)).to.not.include('paypal-secret')
+    expect(JSON.stringify(sanitized)).to.not.include('cus_funder')
+    expect(JSON.stringify(sanitized)).to.not.include('reset-token')
+    expect(sanitized.Offers[0].User.username).to.equal('solver')
+    expect(sanitized.Offers[0].User).to.not.have.property('password')
+    expect(sanitized.assignedUser.name).to.equal('Assignee')
+    expect(sanitized.assignedUser).to.not.have.property('password')
+    expect(sanitized.assignedUser).to.not.have.property('paypal_id')
+  })
+
+  it('leaves non-objects and dates unchanged', () => {
+    expect(stripUserSecrets(null)).to.equal(null)
+    expect(stripUserSecrets(12)).to.equal(12)
+    const date = new Date('2026-09-01T00:00:00.000Z')
+    expect(stripUserSecrets(date)).to.equal(date)
+  })
+
+  it('plain-ifies sequelize-like instances before stripping', () => {
+    const instance = {
+      dataValues: {
+        id: 9,
+        name: 'Nested',
+        password: 'hash',
+        paypal_id: 'hidden'
+      },
+      get({ plain }: { plain: boolean }) {
+        expect(plain).to.equal(true)
+        return { ...this.dataValues }
+      }
+    }
+
+    const sanitized = stripUserSecrets({ User: instance })
+    expect(sanitized.User).to.deep.equal({ id: 9, name: 'Nested' })
+  })
+})
+
+describe('publicUserInclude', () => {
+  it('excludes credential attributes from sequelize User includes', () => {
+    const User = { name: 'User' }
+    expect(publicUserInclude(User)).to.deep.equal({
+      model: User,
+      attributes: { exclude: [...USER_SECRET_ATTRIBUTES] }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`GET /tasks/fetch/:id` is public. Nested `User` includes on orders, offers, assigns, and members were serialized with credential fields (password hashes, PayPal/Stripe/Whop identifiers, recovery and activation tokens). Only the top-level task author previously excluded `password`.

This change:

- Adds `stripUserSecrets` / `publicUserInclude` so those fields are excluded from Sequelize includes.
- Sanitizes every `taskFetch` return path, including GitHub/Bitbucket errors, private tasks, and the default provider branch.
- Adds mocha coverage against a nested public-task payload shaped like the live response.

## Test plan

- [x] `NODE_OPTIONS="--import tsx" mocha test/utils/auth/strip-user-secrets.test.ts` (4 passing)
- [ ] After deploy, `GET /tasks/fetch/:id` on a funded public task should no longer include `password`, `paypal_id`, `customer_id`, `account_id`, or recovery tokens on any nested user.