### PR TITLE
feat(tasks): import issues from Codeberg

### DIFF
--- a/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
@@ -18,6 +18,12 @@ import {
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
 
+const logoCodeberg =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="#2185D0" d="M8 1.5 1 14.5h14L8 1.5zm0 3.2 4.7 8.3H3.3L8 4.7z"/></svg>'
+  )
+
 type ImportIssueDialogProps = {
   open: boolean
   onClose: () => void
@@ -32,8 +38,17 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
   const [notListed, setNotListed] = useState(false)
 
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    try {
+      const host = new URL(nextUrl).hostname.toLowerCase()
+      if (host === 'codeberg.org' || host === 'www.codeberg.org') setProvider('codeberg')
+      else if (host === 'bitbucket.org' || host === 'www.bitbucket.org') setProvider('bitbucket')
+      else if (host === 'github.com' || host === 'www.github.com') setProvider('github')
+    } catch (err) {
+      // keep the currently selected provider until the URL is valid
+    }
   }
 
   const handleCreateTask = async (e: any) => {
@@ -57,7 +72,7 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or Codeberg issue"
               />
             </Typography>
           </DialogContentText>
@@ -113,6 +128,16 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
               >
                 <img width="16" src={logoBitbucket} />
                 <span style={{ marginLeft: 10 }}>Bitbucket</span>
+              </Button>
+
+              <Button
+                color="primary"
+                variant={provider === 'codeberg' ? 'contained' : 'outlined'}
+                id="codeberg"
+                onClick={(e) => setProvider('codeberg')}
+              >
+                <img width="16" src={logoCodeberg} alt="" />
+                <span style={{ marginLeft: 10 }}>Codeberg</span>
               </Button>
             </div>
 

--- a/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
@@ -19,6 +19,12 @@ import isGithubUrl from 'is-github-url'
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
 import api from '../../../../../../consts'
+
+const logoCodeberg =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="#2185D0" d="M8 1.5 1 14.5h14L8 1.5zm0 3.2 4.7 8.3H3.3L8 4.7z"/></svg>'
+  )
 import {
   FullWidthFormControl,
   ProvidersWrapper,
@@ -34,16 +40,29 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
   const [notListed, setNotListed] = useState(false)
 
   const validURL = (url) => {
-    return isGithubUrl(url) || isBitbucketUrl(url)
+    return isGithubUrl(url) || isBitbucketUrl(url) || isCodebergUrl(url)
   }
 
   const isBitbucketUrl = (url) => {
     return url.indexOf('bitbucket') > -1
   }
 
+  const isCodebergUrl = (url) => {
+    try {
+      const host = new URL(url).hostname.toLowerCase()
+      return host === 'codeberg.org' || host === 'www.codeberg.org'
+    } catch (e) {
+      return url.indexOf('codeberg.org') > -1
+    }
+  }
+
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    if (isCodebergUrl(nextUrl)) setProvider('codeberg')
+    else if (isBitbucketUrl(nextUrl)) setProvider('bitbucket')
+    else if (isGithubUrl(nextUrl)) setProvider('github')
   }
 
   const handleCreateTask = async (e: any) => {
@@ -79,7 +98,7 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or Codeberg issue"
               />
             </Typography>
           </DialogContentText>
@@ -134,6 +153,16 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
               >
                 <img width="16" src={logoBitbucket} />
                 <span className="provider-label">Bitbucket</span>
+              </ProviderButton>
+
+              <ProviderButton
+                color="primary"
+                variant={provider === 'codeberg' ? 'contained' : 'outlined'}
+                id="codeberg"
+                onClick={(e) => setProvider('codeberg')}
+              >
+                <img width="16" src={logoCodeberg} alt="" />
+                <span className="provider-label">Codeberg</span>
               </ProviderButton>
             </ProvidersWrapper>
 

--- a/src/client/provider/codeberg.ts
+++ b/src/client/provider/codeberg.ts
@@ -1,0 +1,27 @@
+import requestPromise from 'request-promise'
+
+type CodebergConnectProps = {
+  uri: string
+}
+
+export const codebergIssueUri = (owner: string, repo: string, issueId: string) =>
+  `https://codeberg.org/api/v1/repos/${owner}/${repo}/issues/${issueId}`
+
+export const codebergRepoUri = (owner: string, repo: string) =>
+  `https://codeberg.org/api/v1/repos/${owner}/${repo}`
+
+export const codebergLanguagesUri = (owner: string, repo: string) =>
+  `https://codeberg.org/api/v1/repos/${owner}/${repo}/languages`
+
+export const CodebergConnect = async ({ uri }: CodebergConnectProps) => {
+  const response = await requestPromise({
+    uri,
+    headers: {
+      'User-Agent': 'gitpay',
+      Accept: 'application/json'
+    },
+    json: true
+  })
+
+  return response
+}

--- a/src/modules/tasks/taskBuilds.ts
+++ b/src/modules/tasks/taskBuilds.ts
@@ -1,6 +1,11 @@
 import requestPromise from 'request-promise'
 import models from '../../models'
 import { GithubConnect } from '../../client/provider/github'
+import {
+  CodebergConnect,
+  codebergIssueUri,
+  codebergLanguagesUri
+} from '../../client/provider/codeberg'
 import TaskMail from '../../mail/task'
 import { roleExists } from '../roles'
 import { userExists } from '../users'
@@ -102,6 +107,58 @@ export async function taskBuilds(taskParameters: any) {
       const p = await project(userOrCompany, projectName, userId, 'bitbucket')
       const task = await p.createTask({ ...taskParameters, private: true })
       return task.dataValues
+    }
+
+    case 'codeberg': {
+      const issueData = (await CodebergConnect({
+        uri: codebergIssueUri(userOrCompany, projectName, issueId)
+      })) as any
+
+      if (!issueData || !issueData.title) return false
+      if (!taskParameters.title) taskParameters.title = issueData.title
+      if (!taskParameters.description) taskParameters.description = issueData.body
+
+      let programmingLanguagesResponse = {}
+      try {
+        programmingLanguagesResponse = await CodebergConnect({
+          uri: codebergLanguagesUri(userOrCompany, projectName)
+        })
+      } catch (e) {
+        programmingLanguagesResponse = {}
+      }
+
+      const languages = Object.keys(programmingLanguagesResponse || {})
+
+      const p = await project(userOrCompany, projectName, userId, 'codeberg')
+      const task = await p.createTask(taskParameters)
+
+      for (const language of languages) {
+        let programmingLanguage = await currentModels.ProgrammingLanguage.findOne({
+          where: { name: language }
+        })
+
+        if (!programmingLanguage) {
+          programmingLanguage = await currentModels.ProgrammingLanguage.create({
+            name: language
+          })
+        }
+
+        await currentModels.ProjectProgrammingLanguage.create({
+          projectId: task.ProjectId,
+          programmingLanguageId: programmingLanguage.id
+        })
+      }
+
+      const taskData = task.dataValues
+      const userData = await task.getUser()
+
+      if (userData.receiveNotifications) {
+        TaskMail.new(userData, taskData)
+      }
+
+      await notifyNewIssue(taskData, userData)
+
+      return { ...taskData, ProjectId: taskData.ProjectId }
     }
 
     default: {

--- a/src/modules/tasks/taskFetch.ts
+++ b/src/modules/tasks/taskFetch.ts
@@ -7,6 +7,7 @@ import { userExists } from '../users'
 // @ts-ignore - ip has no type definitions
 import { memberExists } from '../members'
 import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
+import { CodebergConnect, codebergIssueUri, codebergRepoUri } from '../../client/provider/codeberg'
 
 const currentModels = models as any
 
@@ -307,6 +308,113 @@ export async function taskFetch(taskParams: any) {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Bitbucket response error')
+        // eslint-disable-next-line no-console
+        console.log(e)
+        return data.dataValues
+      }
+
+    case 'codeberg':
+      try {
+        const issueDataJsonCodeberg = (await CodebergConnect({
+          uri: codebergIssueUri(userOrCompany, projectName, issueId)
+        })) as any
+
+        const assigned = await currentModels.Assign.findOne({
+          where: {
+            id: data.assigned
+          },
+          include: [currentModels.User]
+        }).catch((e: any) => {})
+
+        let repoUrl = `https://codeberg.org/${userOrCompany}/${projectName}`
+        let ownerUrl = `https://codeberg.org/${userOrCompany}`
+        try {
+          const repoInfoJSON = (await CodebergConnect({
+            uri: codebergRepoUri(userOrCompany, projectName)
+          })) as any
+          repoUrl = repoInfoJSON.html_url || repoUrl
+          ownerUrl = repoInfoJSON.owner?.html_url || ownerUrl
+        } catch (e) {
+          // keep constructed URLs
+        }
+
+        const responseCodeberg = {
+          id: data.dataValues.id,
+          url: issueUrl,
+          private: data.dataValues.private,
+          not_listed: data.dataValues.not_listed,
+          title: data.dataValues.title,
+          description: data.dataValues.description,
+          value: data.dataValues.value || 0,
+          deadline: data.dataValues.deadline,
+          level: data.dataValues.level,
+          status: data.dataValues.status,
+          state: data.dataValues.state,
+          assigned: data.dataValues.assigned,
+          assignedUser: assigned && assigned.dataValues.User.dataValues,
+          User: data.dataValues && data.dataValues.User && data.dataValues.User.dataValues,
+          paid: data.dataValues.paid,
+          transfer_id: data.dataValues.transfer_id,
+          provider: data.dataValues.provider,
+          metadata: {
+            id: issueId,
+            user: userOrCompany,
+            company: userOrCompany,
+            projectName: projectName,
+            repoUrl,
+            ownerUrl,
+            labels: issueDataJsonCodeberg.labels,
+            issue: {
+              ...issueDataJsonCodeberg,
+              state: issueDataJsonCodeberg.state,
+              body: issueDataJsonCodeberg.body,
+              user: {
+                login:
+                  issueDataJsonCodeberg.user?.login || issueDataJsonCodeberg.user?.username,
+                avatar_url: issueDataJsonCodeberg.user?.avatar_url
+              }
+            }
+          },
+          orders: data.dataValues.Orders,
+          Transfer: data.dataValues.Transfer,
+          Assigns: data.dataValues.Assigns,
+          members: data.dataValues.Members,
+          Offers: data.dataValues.Offers,
+          histories: data.dataValues.Histories,
+          Project: data.dataValues.Project && {
+            ...data.dataValues.Project.dataValues,
+            organization: data.dataValues.Project.dataValues.Organization.dataValues
+          }
+        }
+
+        if (!data.title || data.title !== issueDataJsonCodeberg.title) {
+          const dataTitleUpdate = await data.update(
+            { title: issueDataJsonCodeberg.title },
+            {
+              where: {
+                id: data.id
+              }
+            }
+          )
+          responseCodeberg.title = dataTitleUpdate.title
+        }
+        if (data.status !== 'in_progress' && data.status !== issueDataJsonCodeberg.state) {
+          const dataStatusUpdate = await data.update(
+            { status: issueDataJsonCodeberg.state },
+            {
+              where: {
+                id: data.id
+              },
+              returning: true
+            }
+          )
+          responseCodeberg.status = dataStatusUpdate.status
+        }
+
+        return responseCodeberg
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log('Codeberg response error')
         // eslint-disable-next-line no-console
         console.log(e)
         return data.dataValues

--- a/src/utils/issue/parse-and-validate-issue-url.ts
+++ b/src/utils/issue/parse-and-validate-issue-url.ts
@@ -15,12 +15,16 @@ export function parseAndValidateIssueUrl(
   // Only allow expected hosts for supported providers
   const isGithubHost = hostname === 'github.com' || hostname === 'www.github.com'
   const isBitbucketHost = hostname === 'bitbucket.org' || hostname === 'www.bitbucket.org'
+  const isCodebergHost = hostname === 'codeberg.org' || hostname === 'www.codeberg.org'
 
   if (provider === 'github' && !isGithubHost) {
     throw new Error('URL host is not allowed for GitHub provider')
   }
   if (provider === 'bitbucket' && !isBitbucketHost) {
     throw new Error('URL host is not allowed for Bitbucket provider')
+  }
+  if (provider === 'codeberg' && !isCodebergHost) {
+    throw new Error('URL host is not allowed for Codeberg provider')
   }
 
   // Basic path validation: /owner/repo/issues/number

--- a/test/utils/issue/parse-and-validate-issue-url.test.ts
+++ b/test/utils/issue/parse-and-validate-issue-url.test.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai'
+import nock from 'nock'
+import { parseAndValidateIssueUrl } from '../../../src/utils/issue/parse-and-validate-issue-url'
+import { CodebergConnect, codebergIssueUri } from '../../../src/client/provider/codeberg'
+
+describe('parseAndValidateIssueUrl', () => {
+  it('parses a GitHub issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1150', 'github')
+    ).to.deep.equal({
+      userOrCompany: 'worknenjoy',
+      projectName: 'gitpay',
+      issueId: '1150'
+    })
+  })
+
+  it('parses a Bitbucket issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://bitbucket.org/atlassian/atlas/issues/12', 'bitbucket')
+    ).to.deep.equal({
+      userOrCompany: 'atlassian',
+      projectName: 'atlas',
+      issueId: '12'
+    })
+  })
+
+  it('parses a Codeberg issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://codeberg.org/forgejo/forgejo/issues/1', 'codeberg')
+    ).to.deep.equal({
+      userOrCompany: 'forgejo',
+      projectName: 'forgejo',
+      issueId: '1'
+    })
+  })
+
+  it('parses www.codeberg.org', () => {
+    expect(
+      parseAndValidateIssueUrl('https://www.codeberg.org/owner/repo/issues/99', 'codeberg')
+    ).to.deep.equal({
+      userOrCompany: 'owner',
+      projectName: 'repo',
+      issueId: '99'
+    })
+  })
+
+  it('rejects a Codeberg host when the provider is GitHub', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://codeberg.org/forgejo/forgejo/issues/1', 'github')
+    ).to.throw('URL host is not allowed for GitHub provider')
+  })
+
+  it('rejects a GitHub host when the provider is Codeberg', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1150', 'codeberg')
+    ).to.throw('URL host is not allowed for Codeberg provider')
+  })
+
+  it('rejects a non-issue path', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://codeberg.org/forgejo/forgejo', 'codeberg')
+    ).to.throw('Repository URL does not match expected issue pattern')
+  })
+})
+
+describe('codebergIssueUri', () => {
+  it('builds the Forgejo issue API URL used to import Codeberg issues', () => {
+    expect(codebergIssueUri('forgejo', 'forgejo', '1')).to.equal(
+      'https://codeberg.org/api/v1/repos/forgejo/forgejo/issues/1'
+    )
+  })
+})
+
+describe('CodebergConnect', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('loads a public Codeberg issue through the shipped client', async () => {
+    const scope = nock('https://codeberg.org', {
+      reqheaders: {
+        'User-Agent': 'gitpay',
+        Accept: 'application/json'
+      }
+    })
+      .get('/api/v1/repos/forgejo/forgejo/issues/1')
+      .reply(200, {
+        number: 1,
+        title: 'Configure Woodpecker',
+        body: 'ci',
+        state: 'closed',
+        html_url: 'https://codeberg.org/forgejo/forgejo/issues/1',
+        user: { login: 'Ghost', avatar_url: 'https://codeberg.org/avatar.png' }
+      })
+
+    const issue = await CodebergConnect({
+      uri: codebergIssueUri('forgejo', 'forgejo', '1')
+    })
+
+    expect(scope.isDone()).to.equal(true)
+    expect(issue.title).to.equal('Configure Woodpecker')
+    expect(issue.state).to.equal('closed')
+    expect(issue.user.login).to.equal('Ghost')
+  })
+})


### PR DESCRIPTION
## Summary

Gitpay could only import GitHub and Bitbucket issues. Users who reached import after registering with a Codeberg URL were stuck (#1150).

This adds Codeberg as a third provider:

- `parseAndValidateIssueUrl` accepts `codeberg.org` / `www.codeberg.org` when `provider=codeberg`, and still rejects host/provider mismatches.
- Create and fetch talk to the public Forgejo API (`/api/v1/repos/:owner/:repo/issues/:id`).
- Both import dialogs gain a Codeberg button and recognize Codeberg URLs.

GitHub bot comments stay GitHub-only. Private Codeberg repos are out of scope (no OAuth app yet).

## Test plan

- [x] `NODE_OPTIONS="--import tsx" mocha test/utils/issue/parse-and-validate-issue-url.test.ts` (9 passing, including a nock of the shipped `CodebergConnect` client)
- [ ] In the UI, paste `https://codeberg.org/forgejo/forgejo/issues/1`, select Codeberg, and confirm the task title/body import
- [ ] Confirm a GitHub URL still imports, and a Codeberg URL with the GitHub provider selected is rejected

Fixes #1150