### PR TITLE
feat(tasks): import issues from GitLab

### DIFF
--- a/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material'
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
+import logoGitlab from 'images/gitlab-logo.png'
 
 type ImportIssueDialogProps = {
   open: boolean
@@ -32,8 +33,17 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
   const [notListed, setNotListed] = useState(false)
 
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    try {
+      const host = new URL(nextUrl).hostname.toLowerCase()
+      if (host === 'gitlab.com' || host === 'www.gitlab.com') setProvider('gitlab')
+      else if (host === 'bitbucket.org' || host === 'www.bitbucket.org') setProvider('bitbucket')
+      else if (host === 'github.com' || host === 'www.github.com') setProvider('github')
+    } catch (err) {
+      // keep the currently selected provider until the URL is valid
+    }
   }
 
   const handleCreateTask = async (e: any) => {
@@ -57,7 +67,7 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or GitLab issue"
               />
             </Typography>
           </DialogContentText>
@@ -106,6 +116,7 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
               </Button>
 
               <Button
+                style={{ marginRight: 10 }}
                 color="primary"
                 variant={provider === 'bitbucket' ? 'contained' : 'outlined'}
                 id="bitbucket"
@@ -113,6 +124,16 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
               >
                 <img width="16" src={logoBitbucket} />
                 <span style={{ marginLeft: 10 }}>Bitbucket</span>
+              </Button>
+
+              <Button
+                color="primary"
+                variant={provider === 'gitlab' ? 'contained' : 'outlined'}
+                id="gitlab"
+                onClick={(e) => setProvider('gitlab')}
+              >
+                <img width="16" src={logoGitlab} alt="" />
+                <span style={{ marginLeft: 10 }}>Gitlab</span>
               </Button>
             </div>
 

--- a/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import isGithubUrl from 'is-github-url'
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
+import logoGitlab from 'images/gitlab-logo.png'
 import api from '../../../../../../consts'
 import {
   FullWidthFormControl,
@@ -34,16 +35,29 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
   const [notListed, setNotListed] = useState(false)
 
   const validURL = (url) => {
-    return isGithubUrl(url) || isBitbucketUrl(url)
+    return isGithubUrl(url) || isBitbucketUrl(url) || isGitlabUrl(url)
   }
 
   const isBitbucketUrl = (url) => {
     return url.indexOf('bitbucket') > -1
   }
 
+  const isGitlabUrl = (url) => {
+    try {
+      const host = new URL(url).hostname.toLowerCase()
+      return host === 'gitlab.com' || host === 'www.gitlab.com'
+    } catch (e) {
+      return url.indexOf('gitlab.com') > -1
+    }
+  }
+
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    if (isGitlabUrl(nextUrl)) setProvider('gitlab')
+    else if (isBitbucketUrl(nextUrl)) setProvider('bitbucket')
+    else if (isGithubUrl(nextUrl)) setProvider('github')
   }
 
   const handleCreateTask = async (e: any) => {
@@ -79,7 +93,7 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or GitLab issue"
               />
             </Typography>
           </DialogContentText>
@@ -134,6 +148,16 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
               >
                 <img width="16" src={logoBitbucket} />
                 <span className="provider-label">Bitbucket</span>
+              </ProviderButton>
+
+              <ProviderButton
+                color="primary"
+                variant={provider === 'gitlab' ? 'contained' : 'outlined'}
+                id="gitlab"
+                onClick={(e) => setProvider('gitlab')}
+              >
+                <img width="16" src={logoGitlab} alt="" />
+                <span className="provider-label">Gitlab</span>
               </ProviderButton>
             </ProvidersWrapper>
 

--- a/src/client/provider/gitlab.ts
+++ b/src/client/provider/gitlab.ts
@@ -1,0 +1,35 @@
+import requestPromise from 'request-promise'
+
+type GitlabConnectProps = {
+  uri: string
+}
+
+export const gitlabProjectPathParam = (projectPath: string) => encodeURIComponent(projectPath)
+
+export const gitlabIssueUri = (projectPath: string, issueId: string) =>
+  `https://gitlab.com/api/v4/projects/${gitlabProjectPathParam(projectPath)}/issues/${issueId}`
+
+export const gitlabProjectUri = (projectPath: string) =>
+  `https://gitlab.com/api/v4/projects/${gitlabProjectPathParam(projectPath)}`
+
+export const gitlabLanguagesUri = (projectPath: string) =>
+  `https://gitlab.com/api/v4/projects/${gitlabProjectPathParam(projectPath)}/languages`
+
+export const gitlabStateToGitpay = (state?: string | null): string => {
+  if (state === 'opened' || state === 'reopened') return 'open'
+  if (state === 'closed') return 'closed'
+  return state || 'open'
+}
+
+export const GitlabConnect = async ({ uri }: GitlabConnectProps) => {
+  const response = await requestPromise({
+    uri,
+    headers: {
+      'User-Agent': 'gitpay',
+      Accept: 'application/json'
+    },
+    json: true
+  })
+
+  return response
+}

--- a/src/modules/tasks/taskBuilds.ts
+++ b/src/modules/tasks/taskBuilds.ts
@@ -1,6 +1,11 @@
 import requestPromise from 'request-promise'
 import models from '../../models'
 import { GithubConnect } from '../../client/provider/github'
+import {
+  GitlabConnect,
+  gitlabIssueUri,
+  gitlabLanguagesUri
+} from '../../client/provider/gitlab'
 import TaskMail from '../../mail/task'
 import { roleExists } from '../roles'
 import { userExists } from '../users'
@@ -14,7 +19,10 @@ const currentModels = models as any
 export async function taskBuilds(taskParameters: any) {
   const repoUrl = taskParameters.url
   const provider = taskParameters.provider
-  const { userOrCompany, projectName, issueId } = parseAndValidateIssueUrl(repoUrl, provider)
+  const { userOrCompany, projectName, issueId, projectPath } = parseAndValidateIssueUrl(
+    repoUrl,
+    provider
+  )
   const userId = taskParameters.userId
 
   if (!userId) return false
@@ -102,6 +110,61 @@ export async function taskBuilds(taskParameters: any) {
       const p = await project(userOrCompany, projectName, userId, 'bitbucket')
       const task = await p.createTask({ ...taskParameters, private: true })
       return task.dataValues
+    }
+
+    case 'gitlab': {
+      const gitlabPath = projectPath || `${userOrCompany}/${projectName}`
+      const issueData = (await GitlabConnect({
+        uri: gitlabIssueUri(gitlabPath, issueId)
+      })) as any
+
+      if (!issueData || !issueData.title) return false
+      if (!taskParameters.title) taskParameters.title = issueData.title
+      if (!taskParameters.description) {
+        taskParameters.description = issueData.description
+      }
+
+      let programmingLanguagesResponse = {}
+      try {
+        programmingLanguagesResponse = await GitlabConnect({
+          uri: gitlabLanguagesUri(gitlabPath)
+        })
+      } catch (e) {
+        programmingLanguagesResponse = {}
+      }
+
+      const languages = Object.keys(programmingLanguagesResponse || {})
+
+      const p = await project(userOrCompany, projectName, userId, 'gitlab')
+      const task = await p.createTask(taskParameters)
+
+      for (const language of languages) {
+        let programmingLanguage = await currentModels.ProgrammingLanguage.findOne({
+          where: { name: language }
+        })
+
+        if (!programmingLanguage) {
+          programmingLanguage = await currentModels.ProgrammingLanguage.create({
+            name: language
+          })
+        }
+
+        await currentModels.ProjectProgrammingLanguage.create({
+          projectId: task.ProjectId,
+          programmingLanguageId: programmingLanguage.id
+        })
+      }
+
+      const taskData = task.dataValues
+      const userData = await task.getUser()
+
+      if (userData.receiveNotifications) {
+        TaskMail.new(userData, taskData)
+      }
+
+      await notifyNewIssue(taskData, userData)
+
+      return { ...taskData, ProjectId: taskData.ProjectId }
     }
 
     default: {

--- a/src/modules/tasks/taskFetch.ts
+++ b/src/modules/tasks/taskFetch.ts
@@ -7,6 +7,13 @@ import { userExists } from '../users'
 // @ts-ignore - ip has no type definitions
 import { memberExists } from '../members'
 import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
+import {
+  GitlabConnect,
+  gitlabIssueUri,
+  gitlabProjectUri,
+  gitlabStateToGitpay
+} from '../../client/provider/gitlab'
+import { parseGitlabIssuePath } from '../../utils/issue/parse-and-validate-issue-url'
 
 const currentModels = models as any
 
@@ -307,6 +314,123 @@ export async function taskFetch(taskParams: any) {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Bitbucket response error')
+        // eslint-disable-next-line no-console
+        console.log(e)
+        return data.dataValues
+      }
+
+    case 'gitlab':
+      try {
+        const parsedGitlab = parseGitlabIssuePath(issueUrl)
+        const gitlabPath = parsedGitlab.projectPath
+        const gitlabIssueId = parsedGitlab.issueId
+        const gitlabUser = parsedGitlab.userOrCompany
+        const gitlabProjectName = parsedGitlab.projectName
+
+        const issueDataJsonGitlab = (await GitlabConnect({
+          uri: gitlabIssueUri(gitlabPath, gitlabIssueId)
+        })) as any
+
+        const assigned = await currentModels.Assign.findOne({
+          where: {
+            id: data.assigned
+          },
+          include: [currentModels.User]
+        }).catch((e: any) => {})
+
+        let repoUrl = `https://gitlab.com/${gitlabPath}`
+        let ownerUrl = `https://gitlab.com/${gitlabUser}`
+        try {
+          const repoInfoJSON = (await GitlabConnect({
+            uri: gitlabProjectUri(gitlabPath)
+          })) as any
+          repoUrl = repoInfoJSON.web_url || repoUrl
+          ownerUrl = repoInfoJSON.namespace?.web_url || ownerUrl
+        } catch (e) {
+          // keep constructed URLs
+        }
+
+        const gitpayState = gitlabStateToGitpay(issueDataJsonGitlab.state)
+        const labels = (issueDataJsonGitlab.labels || []).map((label: any) =>
+          typeof label === 'string' ? { name: label } : label
+        )
+
+        const responseGitlab = {
+          id: data.dataValues.id,
+          url: issueUrl,
+          private: data.dataValues.private,
+          not_listed: data.dataValues.not_listed,
+          title: data.dataValues.title,
+          description: data.dataValues.description,
+          value: data.dataValues.value || 0,
+          deadline: data.dataValues.deadline,
+          level: data.dataValues.level,
+          status: data.dataValues.status,
+          state: data.dataValues.state,
+          assigned: data.dataValues.assigned,
+          assignedUser: assigned && assigned.dataValues.User.dataValues,
+          User: data.dataValues && data.dataValues.User && data.dataValues.User.dataValues,
+          paid: data.dataValues.paid,
+          transfer_id: data.dataValues.transfer_id,
+          provider: data.dataValues.provider,
+          metadata: {
+            id: gitlabIssueId,
+            user: gitlabUser,
+            company: gitlabUser,
+            projectName: gitlabProjectName,
+            repoUrl,
+            ownerUrl,
+            labels,
+            issue: {
+              ...issueDataJsonGitlab,
+              state: gitpayState,
+              body: issueDataJsonGitlab.description,
+              user: {
+                login: issueDataJsonGitlab.author?.username,
+                avatar_url: issueDataJsonGitlab.author?.avatar_url
+              }
+            }
+          },
+          orders: data.dataValues.Orders,
+          Transfer: data.dataValues.Transfer,
+          Assigns: data.dataValues.Assigns,
+          members: data.dataValues.Members,
+          Offers: data.dataValues.Offers,
+          histories: data.dataValues.Histories,
+          Project: data.dataValues.Project && {
+            ...data.dataValues.Project.dataValues,
+            organization: data.dataValues.Project.dataValues.Organization.dataValues
+          }
+        }
+
+        if (!data.title || data.title !== issueDataJsonGitlab.title) {
+          const dataTitleUpdate = await data.update(
+            { title: issueDataJsonGitlab.title },
+            {
+              where: {
+                id: data.id
+              }
+            }
+          )
+          responseGitlab.title = dataTitleUpdate.title
+        }
+        if (data.status !== 'in_progress' && data.status !== gitpayState) {
+          const dataStatusUpdate = await data.update(
+            { status: gitpayState },
+            {
+              where: {
+                id: data.id
+              },
+              returning: true
+            }
+          )
+          responseGitlab.status = dataStatusUpdate.status
+        }
+
+        return responseGitlab
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log('GitLab response error')
         // eslint-disable-next-line no-console
         console.log(e)
         return data.dataValues

--- a/src/utils/issue/parse-and-validate-issue-url.ts
+++ b/src/utils/issue/parse-and-validate-issue-url.ts
@@ -1,9 +1,88 @@
 import url from 'url'
 
-export function parseAndValidateIssueUrl(
-  rawUrl: string,
-  provider: string
-): { userOrCompany: string; projectName: string; issueId: string } {
+export type ParsedIssueUrl = {
+  userOrCompany: string
+  projectName: string
+  issueId: string
+  projectPath: string
+}
+
+const OWNER_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-_.]*$/
+
+const assertSafeSegment = (value: string, kind: 'owner' | 'project') => {
+  if (!value || value === '..') {
+    throw new Error('Repository URL contains invalid path segments')
+  }
+  if (!OWNER_REPO_PATTERN.test(value)) {
+    throw new Error(
+      kind === 'owner'
+        ? 'Repository URL contains an invalid owner/organization name'
+        : 'Repository URL contains an invalid project name'
+    )
+  }
+}
+
+export function parseGitlabIssuePath(rawUrl: string): ParsedIssueUrl {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    throw new Error('Invalid repository URL')
+  }
+
+  const parsed = url.parse(rawUrl)
+  const hostname = (parsed.hostname || '').toLowerCase()
+  const isGitlabHost = hostname === 'gitlab.com' || hostname === 'www.gitlab.com'
+  if (!isGitlabHost) {
+    throw new Error('URL host is not allowed for GitLab provider')
+  }
+
+  const path = parsed.pathname || parsed.path || ''
+  const segments = path.split('/').filter(Boolean)
+
+  let markerIndex = -1
+  for (let i = 0; i < segments.length - 1; i++) {
+    const isIssueMarker = segments[i] === 'issues' || segments[i] === 'work_items'
+    if (isIssueMarker && /^[0-9]+$/.test(segments[i + 1])) {
+      markerIndex = i
+      break
+    }
+  }
+
+  if (markerIndex < 1) {
+    throw new Error('Repository URL does not match expected issue pattern')
+  }
+
+  let projectSegments = segments.slice(0, markerIndex)
+  if (projectSegments[projectSegments.length - 1] === '-') {
+    projectSegments = projectSegments.slice(0, -1)
+  }
+
+  if (projectSegments.length < 2) {
+    throw new Error('Repository URL is missing required components')
+  }
+
+  const issueId = segments[markerIndex + 1]
+  const userOrCompany = projectSegments[0]
+  const projectName = projectSegments[projectSegments.length - 1]
+  const projectPath = projectSegments.join('/')
+
+  if (!userOrCompany || !projectName || !issueId) {
+    throw new Error('Repository URL is missing required components')
+  }
+  if (!/^[0-9]+$/.test(issueId)) {
+    throw new Error('Issue id in URL is not a valid number')
+  }
+
+  for (let i = 0; i < projectSegments.length; i++) {
+    assertSafeSegment(projectSegments[i], i === projectSegments.length - 1 ? 'project' : 'owner')
+  }
+
+  return { userOrCompany, projectName, issueId, projectPath }
+}
+
+export function parseAndValidateIssueUrl(rawUrl: string, provider: string): ParsedIssueUrl {
+  if (provider === 'gitlab') {
+    return parseGitlabIssuePath(rawUrl)
+  }
+
   if (!rawUrl || typeof rawUrl !== 'string') {
     throw new Error('Invalid repository URL')
   }
@@ -46,13 +125,13 @@ export function parseAndValidateIssueUrl(
 
   // Additional safety: restrict owner and repository name to expected patterns
   // GitHub owners and repo names are typically alphanumeric with dashes/underscores and dots.
-  const ownerRepoPattern = /^[A-Za-z0-9][A-Za-z0-9-_.]*$/
-  if (!ownerRepoPattern.test(userOrCompany)) {
-    throw new Error('Repository URL contains an invalid owner/organization name')
-  }
-  if (!ownerRepoPattern.test(projectName)) {
-    throw new Error('Repository URL contains an invalid project name')
-  }
+  assertSafeSegment(userOrCompany, 'owner')
+  assertSafeSegment(projectName, 'project')
 
-  return { userOrCompany, projectName, issueId }
+  return {
+    userOrCompany,
+    projectName,
+    issueId,
+    projectPath: `${userOrCompany}/${projectName}`
+  }
 }

--- a/test/utils/issue/parse-and-validate-issue-url.test.ts
+++ b/test/utils/issue/parse-and-validate-issue-url.test.ts
@@ -1,0 +1,164 @@
+import { expect } from 'chai'
+import nock from 'nock'
+import {
+  parseAndValidateIssueUrl,
+  parseGitlabIssuePath
+} from '../../../src/utils/issue/parse-and-validate-issue-url'
+import {
+  GitlabConnect,
+  gitlabIssueUri,
+  gitlabStateToGitpay
+} from '../../../src/client/provider/gitlab'
+
+describe('parseAndValidateIssueUrl', () => {
+  it('parses a GitHub issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1097', 'github')
+    ).to.deep.equal({
+      userOrCompany: 'worknenjoy',
+      projectName: 'gitpay',
+      issueId: '1097',
+      projectPath: 'worknenjoy/gitpay'
+    })
+  })
+
+  it('parses a Bitbucket issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://bitbucket.org/atlassian/atlas/issues/12', 'bitbucket')
+    ).to.deep.equal({
+      userOrCompany: 'atlassian',
+      projectName: 'atlas',
+      issueId: '12',
+      projectPath: 'atlassian/atlas'
+    })
+  })
+
+  it('parses a GitLab issue URL with /-/issues/', () => {
+    expect(
+      parseAndValidateIssueUrl(
+        'https://gitlab.com/mission-center-devs/mission-center/-/issues/3',
+        'gitlab'
+      )
+    ).to.deep.equal({
+      userOrCompany: 'mission-center-devs',
+      projectName: 'mission-center',
+      issueId: '3',
+      projectPath: 'mission-center-devs/mission-center'
+    })
+  })
+
+  it('parses a GitLab work item URL', () => {
+    expect(
+      parseAndValidateIssueUrl(
+        'https://gitlab.com/mission-center-devs/mission-center/-/work_items/3',
+        'gitlab'
+      )
+    ).to.deep.equal({
+      userOrCompany: 'mission-center-devs',
+      projectName: 'mission-center',
+      issueId: '3',
+      projectPath: 'mission-center-devs/mission-center'
+    })
+  })
+
+  it('parses nested GitLab groups', () => {
+    expect(
+      parseGitlabIssuePath('https://gitlab.com/group/sub/project/-/issues/12')
+    ).to.deep.equal({
+      userOrCompany: 'group',
+      projectName: 'project',
+      issueId: '12',
+      projectPath: 'group/sub/project'
+    })
+  })
+
+  it('parses www.gitlab.com', () => {
+    expect(
+      parseAndValidateIssueUrl('https://www.gitlab.com/owner/repo/-/issues/99', 'gitlab')
+    ).to.deep.equal({
+      userOrCompany: 'owner',
+      projectName: 'repo',
+      issueId: '99',
+      projectPath: 'owner/repo'
+    })
+  })
+
+  it('rejects a GitLab host when the provider is GitHub', () => {
+    expect(() =>
+      parseAndValidateIssueUrl(
+        'https://gitlab.com/mission-center-devs/mission-center/-/issues/3',
+        'github'
+      )
+    ).to.throw('URL host is not allowed for GitHub provider')
+  })
+
+  it('rejects a GitHub host when the provider is GitLab', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1097', 'gitlab')
+    ).to.throw('URL host is not allowed for GitLab provider')
+  })
+
+  it('rejects a non-issue GitLab path', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://gitlab.com/mission-center-devs/mission-center', 'gitlab')
+    ).to.throw('Repository URL does not match expected issue pattern')
+  })
+})
+
+describe('gitlabIssueUri', () => {
+  it('builds the GitLab issue API URL with an encoded project path', () => {
+    expect(gitlabIssueUri('mission-center-devs/mission-center', '3')).to.equal(
+      'https://gitlab.com/api/v4/projects/mission-center-devs%2Fmission-center/issues/3'
+    )
+    expect(gitlabIssueUri('group/sub/project', '12')).to.equal(
+      'https://gitlab.com/api/v4/projects/group%2Fsub%2Fproject/issues/12'
+    )
+  })
+})
+
+describe('gitlabStateToGitpay', () => {
+  it('maps GitLab opened/closed onto gitpay open/closed', () => {
+    expect(gitlabStateToGitpay('opened')).to.equal('open')
+    expect(gitlabStateToGitpay('reopened')).to.equal('open')
+    expect(gitlabStateToGitpay('closed')).to.equal('closed')
+  })
+})
+
+describe('GitlabConnect', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('loads a public GitLab issue through the shipped client', async () => {
+    const scope = nock('https://gitlab.com', {
+      reqheaders: {
+        'User-Agent': 'gitpay',
+        Accept: 'application/json'
+      }
+    })
+      .get(/\/api\/v4\/projects\/.+\/issues\/3$/)
+      .reply(200, {
+        iid: 3,
+        title: 'Add network usage column to the Apps page',
+        description: 'Show network usage',
+        state: 'closed',
+        web_url: 'https://gitlab.com/mission-center-devs/mission-center/-/work_items/3',
+        labels: ['Type::Feature/Enhancement'],
+        author: {
+          username: 'kicsyromy',
+          avatar_url: 'https://gitlab.com/uploads/-/system/user/avatar/2727510/avatar.png'
+        }
+      })
+
+    const issue = await GitlabConnect({
+      uri: gitlabIssueUri('mission-center-devs/mission-center', '3')
+    })
+
+    expect(scope.isDone()).to.equal(true)
+    expect(issue.title).to.equal('Add network usage column to the Apps page')
+    expect(issue.state).to.equal('closed')
+    expect(issue.description).to.equal('Show network usage')
+    expect(issue.author.username).to.equal('kicsyromy')
+    expect(gitlabStateToGitpay(issue.state)).to.equal('closed')
+  })
+})


### PR DESCRIPTION
## Summary
Gitpay can import GitHub and Bitbucket issues. This adds GitLab.com so a URL like https://gitlab.com/mission-center-devs/mission-center/-/issues/3 (the example on #1097) creates a task.

## What changed
- Parse `gitlab.com` / `www.gitlab.com` issue URLs, including nested groups, `/-/issues/:id`, and `/-/work_items/:id`
- `GitlabConnect` client for the public REST API (`/projects/:path/issues/:iid`, project metadata, languages)
- Map GitLab `opened` to gitpay `open` and `description` to the issue body the UI already expects
- GitLab button on both import dialogs; pasting a gitlab.com URL selects GitLab

## Tests
Mocha coverage of the parser plus a nock of the shipped `GitlabConnect` client (12 passing).

Closes #1097