### PR TITLE
feat(tasks): import issues from KDE Bugzilla

### DIFF
--- a/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/molecules/dialogs/import-issue-dialog/import-issue-dialog.tsx
@@ -18,6 +18,12 @@ import {
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
 
+const logoKde =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" rx="3" fill="#1D99F3"/><text x="8" y="12" text-anchor="middle" font-size="10" font-family="sans-serif" fill="#fff">K</text></svg>'
+  )
+
 type ImportIssueDialogProps = {
   open: boolean
   onClose: () => void
@@ -32,8 +38,17 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
   const [notListed, setNotListed] = useState(false)
 
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    try {
+      const host = new URL(nextUrl).hostname.toLowerCase()
+      if (host === 'bugs.kde.org' || host === 'www.bugs.kde.org') setProvider('kde')
+      else if (host === 'bitbucket.org' || host === 'www.bitbucket.org') setProvider('bitbucket')
+      else if (host === 'github.com' || host === 'www.github.com') setProvider('github')
+    } catch (err) {
+      // keep the currently selected provider until the URL is valid
+    }
   }
 
   const handleCreateTask = async (e: any) => {
@@ -57,7 +72,7 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or KDE Bugzilla issue"
               />
             </Typography>
           </DialogContentText>
@@ -106,6 +121,7 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
               </Button>
 
               <Button
+                style={{ marginRight: 10 }}
                 color="primary"
                 variant={provider === 'bitbucket' ? 'contained' : 'outlined'}
                 id="bitbucket"
@@ -113,6 +129,16 @@ const ImportIssueDialog = ({ open, onClose, onImport }: ImportIssueDialogProps) 
               >
                 <img width="16" src={logoBitbucket} />
                 <span style={{ marginLeft: 10 }}>Bitbucket</span>
+              </Button>
+
+              <Button
+                color="primary"
+                variant={provider === 'kde' ? 'contained' : 'outlined'}
+                id="kde"
+                onClick={(e) => setProvider('kde')}
+              >
+                <img width="16" src={logoKde} alt="" />
+                <span style={{ marginLeft: 10 }}>KDE</span>
               </Button>
             </div>
 

--- a/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
+++ b/frontend/src/components/design-library/organisms/layouts/topbar-layouts/topbar-layout/import-issue-dialog.tsx
@@ -18,6 +18,12 @@ import {
 import isGithubUrl from 'is-github-url'
 import logoGithub from 'images/github-logo.png'
 import logoBitbucket from 'images/bitbucket-logo.png'
+
+const logoKde =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" rx="3" fill="#1D99F3"/><text x="8" y="12" text-anchor="middle" font-size="10" font-family="sans-serif" fill="#fff">K</text></svg>'
+  )
 import api from '../../../../../../consts'
 import {
   FullWidthFormControl,
@@ -34,16 +40,29 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
   const [notListed, setNotListed] = useState(false)
 
   const validURL = (url) => {
-    return isGithubUrl(url) || isBitbucketUrl(url)
+    return isGithubUrl(url) || isBitbucketUrl(url) || isKdeUrl(url)
   }
 
   const isBitbucketUrl = (url) => {
     return url.indexOf('bitbucket') > -1
   }
 
+  const isKdeUrl = (url) => {
+    try {
+      const host = new URL(url).hostname.toLowerCase()
+      return host === 'bugs.kde.org' || host === 'www.bugs.kde.org'
+    } catch (e) {
+      return url.indexOf('bugs.kde.org') > -1
+    }
+  }
+
   const onChange = (e: any) => {
-    setUrl(e.target.value)
+    const nextUrl = e.target.value
+    setUrl(nextUrl)
     setError(false)
+    if (isKdeUrl(nextUrl)) setProvider('kde')
+    else if (isBitbucketUrl(nextUrl)) setProvider('bitbucket')
+    else if (isGithubUrl(nextUrl)) setProvider('github')
   }
 
   const handleCreateTask = async (e: any) => {
@@ -79,7 +98,7 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
             <Typography variant="subtitle1" gutterBottom>
               <FormattedMessage
                 id="task.actions.insert.subheading"
-                defaultMessage="Paste the url of an incident of Github or Bitbucket"
+                defaultMessage="Paste the URL of a GitHub, Bitbucket, or KDE Bugzilla issue"
               />
             </Typography>
           </DialogContentText>
@@ -134,6 +153,16 @@ const ImportIssueDialog = ({ user, open, onClose, onCreate }) => {
               >
                 <img width="16" src={logoBitbucket} />
                 <span className="provider-label">Bitbucket</span>
+              </ProviderButton>
+
+              <ProviderButton
+                color="primary"
+                variant={provider === 'kde' ? 'contained' : 'outlined'}
+                id="kde"
+                onClick={(e) => setProvider('kde')}
+              >
+                <img width="16" src={logoKde} alt="" />
+                <span className="provider-label">KDE</span>
               </ProviderButton>
             </ProvidersWrapper>
 

--- a/src/client/provider/kde.ts
+++ b/src/client/provider/kde.ts
@@ -1,0 +1,32 @@
+import requestPromise from 'request-promise'
+
+type KdeConnectProps = {
+  uri: string
+}
+
+export const kdeBugUri = (bugId: string) => `https://bugs.kde.org/rest/bug/${bugId}`
+
+export const kdeBugCommentsUri = (bugId: string) =>
+  `https://bugs.kde.org/rest/bug/${bugId}/comment`
+
+export const kdeStateToGitpay = (bug: { is_open?: boolean; status?: string } | null | undefined): string => {
+  if (bug && typeof bug.is_open === 'boolean') {
+    return bug.is_open ? 'open' : 'closed'
+  }
+  const status = (bug?.status || '').toUpperCase()
+  if (['RESOLVED', 'VERIFIED', 'CLOSED'].includes(status)) return 'closed'
+  return 'open'
+}
+
+export const KdeConnect = async ({ uri }: KdeConnectProps) => {
+  const response = await requestPromise({
+    uri,
+    headers: {
+      'User-Agent': 'gitpay',
+      Accept: 'application/json'
+    },
+    json: true
+  })
+
+  return response
+}

--- a/src/modules/tasks/taskBuilds.ts
+++ b/src/modules/tasks/taskBuilds.ts
@@ -1,6 +1,11 @@
 import requestPromise from 'request-promise'
 import models from '../../models'
 import { GithubConnect } from '../../client/provider/github'
+import {
+  KdeConnect,
+  kdeBugCommentsUri,
+  kdeBugUri
+} from '../../client/provider/kde'
 import TaskMail from '../../mail/task'
 import { roleExists } from '../roles'
 import { userExists } from '../users'
@@ -102,6 +107,44 @@ export async function taskBuilds(taskParameters: any) {
       const p = await project(userOrCompany, projectName, userId, 'bitbucket')
       const task = await p.createTask({ ...taskParameters, private: true })
       return task.dataValues
+    }
+
+    case 'kde': {
+      const bugPayload = (await KdeConnect({ uri: kdeBugUri(issueId) })) as any
+      const bug = Array.isArray(bugPayload?.bugs) ? bugPayload.bugs[0] : null
+      if (!bug || !bug.summary) return false
+      if (!taskParameters.title) taskParameters.title = bug.summary
+
+      if (!taskParameters.description) {
+        try {
+          const commentsPayload = (await KdeConnect({
+            uri: kdeBugCommentsUri(issueId)
+          })) as any
+          const comments =
+            commentsPayload?.bugs?.[String(bug.id)]?.comments ||
+            commentsPayload?.bugs?.[issueId]?.comments ||
+            []
+          taskParameters.description = comments[0]?.text || ''
+        } catch (e) {
+          taskParameters.description = ''
+        }
+      }
+
+      const orgName = bug.product || userOrCompany || 'kde'
+      const kdeProjectName = bug.component || projectName || 'bugs'
+      const p = await project(orgName, kdeProjectName, userId, 'kde')
+      const task = await p.createTask(taskParameters)
+
+      const taskData = task.dataValues
+      const userData = await task.getUser()
+
+      if (userData.receiveNotifications) {
+        TaskMail.new(userData, taskData)
+      }
+
+      await notifyNewIssue(taskData, userData)
+
+      return { ...taskData, ProjectId: taskData.ProjectId }
     }
 
     default: {

--- a/src/modules/tasks/taskFetch.ts
+++ b/src/modules/tasks/taskFetch.ts
@@ -7,6 +7,8 @@ import { userExists } from '../users'
 // @ts-ignore - ip has no type definitions
 import { memberExists } from '../members'
 import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
+import { KdeConnect, kdeBugUri, kdeStateToGitpay } from '../../client/provider/kde'
+import { parseKdeBugUrl } from '../../utils/issue/parse-and-validate-issue-url'
 
 const currentModels = models as any
 
@@ -307,6 +309,118 @@ export async function taskFetch(taskParams: any) {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Bitbucket response error')
+        // eslint-disable-next-line no-console
+        console.log(e)
+        return data.dataValues
+      }
+
+    case 'kde':
+      try {
+        const parsedKde = parseKdeBugUrl(issueUrl)
+        const kdeBugId = parsedKde.issueId
+        const bugPayload = (await KdeConnect({ uri: kdeBugUri(kdeBugId) })) as any
+        const bug = Array.isArray(bugPayload?.bugs) ? bugPayload.bugs[0] : null
+        if (!bug) {
+          return data.dataValues
+        }
+
+        const assigned = await currentModels.Assign.findOne({
+          where: {
+            id: data.assigned
+          },
+          include: [currentModels.User]
+        }).catch((e: any) => {})
+
+        const gitpayState = kdeStateToGitpay(bug)
+        const product = bug.product || 'kde'
+        const component = bug.component || 'bugs'
+        const repoUrl = `https://bugs.kde.org/buglist.cgi?product=${encodeURIComponent(product)}`
+        const ownerUrl = 'https://bugs.kde.org/'
+        const labels = []
+        if (bug.component) labels.push({ name: String(bug.component) })
+        if (bug.severity) labels.push({ name: String(bug.severity) })
+        if (Array.isArray(bug.keywords)) {
+          for (const keyword of bug.keywords) {
+            labels.push({ name: String(keyword) })
+          }
+        }
+
+        const responseKde = {
+          id: data.dataValues.id,
+          url: issueUrl,
+          private: data.dataValues.private,
+          not_listed: data.dataValues.not_listed,
+          title: data.dataValues.title,
+          description: data.dataValues.description,
+          value: data.dataValues.value || 0,
+          deadline: data.dataValues.deadline,
+          level: data.dataValues.level,
+          status: data.dataValues.status,
+          state: data.dataValues.state,
+          assigned: data.dataValues.assigned,
+          assignedUser: assigned && assigned.dataValues.User.dataValues,
+          User: data.dataValues && data.dataValues.User && data.dataValues.User.dataValues,
+          paid: data.dataValues.paid,
+          transfer_id: data.dataValues.transfer_id,
+          provider: data.dataValues.provider,
+          metadata: {
+            id: kdeBugId,
+            user: product,
+            company: product,
+            projectName: component,
+            repoUrl,
+            ownerUrl,
+            labels,
+            issue: {
+              ...bug,
+              state: gitpayState,
+              body: data.dataValues.description,
+              user: {
+                login: bug.creator_detail?.name || bug.creator,
+                avatar_url: bug.creator_detail?.avatar_url || null
+              }
+            }
+          },
+          orders: data.dataValues.Orders,
+          Transfer: data.dataValues.Transfer,
+          Assigns: data.dataValues.Assigns,
+          members: data.dataValues.Members,
+          Offers: data.dataValues.Offers,
+          histories: data.dataValues.Histories,
+          Project: data.dataValues.Project && {
+            ...data.dataValues.Project.dataValues,
+            organization: data.dataValues.Project.dataValues.Organization.dataValues
+          }
+        }
+
+        if (!data.title || data.title !== bug.summary) {
+          const dataTitleUpdate = await data.update(
+            { title: bug.summary },
+            {
+              where: {
+                id: data.id
+              }
+            }
+          )
+          responseKde.title = dataTitleUpdate.title
+        }
+        if (data.status !== 'in_progress' && data.status !== gitpayState) {
+          const dataStatusUpdate = await data.update(
+            { status: gitpayState },
+            {
+              where: {
+                id: data.id
+              },
+              returning: true
+            }
+          )
+          responseKde.status = dataStatusUpdate.status
+        }
+
+        return responseKde
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log('KDE Bugzilla response error')
         // eslint-disable-next-line no-console
         console.log(e)
         return data.dataValues

--- a/src/utils/issue/parse-and-validate-issue-url.ts
+++ b/src/utils/issue/parse-and-validate-issue-url.ts
@@ -1,9 +1,60 @@
 import url from 'url'
 
-export function parseAndValidateIssueUrl(
-  rawUrl: string,
-  provider: string
-): { userOrCompany: string; projectName: string; issueId: string } {
+export type ParsedIssueUrl = {
+  userOrCompany: string
+  projectName: string
+  issueId: string
+  projectPath: string
+}
+
+export function parseKdeBugUrl(rawUrl: string): ParsedIssueUrl {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    throw new Error('Invalid repository URL')
+  }
+
+  const parsed = url.parse(rawUrl, true)
+  const hostname = (parsed.hostname || '').toLowerCase()
+  const isKdeHost = hostname === 'bugs.kde.org' || hostname === 'www.bugs.kde.org'
+  if (!isKdeHost) {
+    throw new Error('URL host is not allowed for KDE Bugzilla provider')
+  }
+
+  let issueId = ''
+  const queryId = parsed.query && (parsed.query as { id?: string | string[] }).id
+  if (Array.isArray(queryId)) {
+    issueId = String(queryId[0] || '')
+  } else if (queryId) {
+    issueId = String(queryId)
+  }
+
+  if (!issueId) {
+    const segments = (parsed.pathname || '').split('/').filter(Boolean)
+    const last = segments[segments.length - 1]
+    if (last && /^[0-9]+$/.test(last)) {
+      issueId = last
+    }
+  }
+
+  if (!issueId) {
+    throw new Error('Repository URL does not match expected issue pattern')
+  }
+  if (!/^[0-9]+$/.test(issueId)) {
+    throw new Error('Issue id in URL is not a valid number')
+  }
+
+  return {
+    userOrCompany: 'kde',
+    projectName: 'bugs',
+    issueId,
+    projectPath: 'kde/bugs'
+  }
+}
+
+export function parseAndValidateIssueUrl(rawUrl: string, provider: string): ParsedIssueUrl {
+  if (provider === 'kde') {
+    return parseKdeBugUrl(rawUrl)
+  }
+
   if (!rawUrl || typeof rawUrl !== 'string') {
     throw new Error('Invalid repository URL')
   }
@@ -54,5 +105,10 @@ export function parseAndValidateIssueUrl(
     throw new Error('Repository URL contains an invalid project name')
   }
 
-  return { userOrCompany, projectName, issueId }
+  return {
+    userOrCompany,
+    projectName,
+    issueId,
+    projectPath: `${userOrCompany}/${projectName}`
+  }
 }

--- a/test/utils/issue/parse-and-validate-issue-url.test.ts
+++ b/test/utils/issue/parse-and-validate-issue-url.test.ts
@@ -1,0 +1,134 @@
+import { expect } from 'chai'
+import nock from 'nock'
+import {
+  parseAndValidateIssueUrl,
+  parseKdeBugUrl
+} from '../../../src/utils/issue/parse-and-validate-issue-url'
+import {
+  KdeConnect,
+  kdeBugUri,
+  kdeStateToGitpay
+} from '../../../src/client/provider/kde'
+
+describe('parseAndValidateIssueUrl', () => {
+  it('parses a GitHub issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1098', 'github')
+    ).to.deep.equal({
+      userOrCompany: 'worknenjoy',
+      projectName: 'gitpay',
+      issueId: '1098',
+      projectPath: 'worknenjoy/gitpay'
+    })
+  })
+
+  it('parses a Bitbucket issue URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://bitbucket.org/atlassian/atlas/issues/12', 'bitbucket')
+    ).to.deep.equal({
+      userOrCompany: 'atlassian',
+      projectName: 'atlas',
+      issueId: '12',
+      projectPath: 'atlassian/atlas'
+    })
+  })
+
+  it('parses a KDE Bugzilla show_bug.cgi URL', () => {
+    expect(
+      parseAndValidateIssueUrl('https://bugs.kde.org/show_bug.cgi?id=341143', 'kde')
+    ).to.deep.equal({
+      userOrCompany: 'kde',
+      projectName: 'bugs',
+      issueId: '341143',
+      projectPath: 'kde/bugs'
+    })
+  })
+
+  it('parses a numeric KDE Bugzilla path', () => {
+    expect(parseKdeBugUrl('https://bugs.kde.org/341143')).to.deep.equal({
+      userOrCompany: 'kde',
+      projectName: 'bugs',
+      issueId: '341143',
+      projectPath: 'kde/bugs'
+    })
+  })
+
+  it('parses www.bugs.kde.org', () => {
+    expect(
+      parseAndValidateIssueUrl('https://www.bugs.kde.org/show_bug.cgi?id=99', 'kde')
+    ).to.deep.equal({
+      userOrCompany: 'kde',
+      projectName: 'bugs',
+      issueId: '99',
+      projectPath: 'kde/bugs'
+    })
+  })
+
+  it('rejects a KDE host when the provider is GitHub', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://bugs.kde.org/show_bug.cgi?id=341143', 'github')
+    ).to.throw('URL host is not allowed for GitHub provider')
+  })
+
+  it('rejects a GitHub host when the provider is KDE', () => {
+    expect(() =>
+      parseAndValidateIssueUrl('https://github.com/worknenjoy/gitpay/issues/1098', 'kde')
+    ).to.throw('URL host is not allowed for KDE Bugzilla provider')
+  })
+
+  it('rejects a KDE URL without a bug id', () => {
+    expect(() => parseAndValidateIssueUrl('https://bugs.kde.org/', 'kde')).to.throw(
+      'Repository URL does not match expected issue pattern'
+    )
+  })
+})
+
+describe('kdeBugUri', () => {
+  it('builds the Bugzilla REST URL used to import KDE bugs', () => {
+    expect(kdeBugUri('341143')).to.equal('https://bugs.kde.org/rest/bug/341143')
+  })
+})
+
+describe('kdeStateToGitpay', () => {
+  it('maps Bugzilla is_open onto gitpay open/closed', () => {
+    expect(kdeStateToGitpay({ is_open: true, status: 'CONFIRMED' })).to.equal('open')
+    expect(kdeStateToGitpay({ is_open: false, status: 'RESOLVED' })).to.equal('closed')
+    expect(kdeStateToGitpay({ status: 'VERIFIED' })).to.equal('closed')
+  })
+})
+
+describe('KdeConnect', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('loads a public KDE bug through the shipped client', async () => {
+    const scope = nock('https://bugs.kde.org', {
+      reqheaders: {
+        'User-Agent': 'gitpay',
+        Accept: 'application/json'
+      }
+    })
+      .get('/rest/bug/341143')
+      .reply(200, {
+        bugs: [
+          {
+            id: 341143,
+            summary: 'Bring back per-virtual-desktop wallpapers',
+            status: 'CONFIRMED',
+            is_open: true,
+            product: 'plasmashell',
+            component: 'Image & Slideshow wallpaper plugins',
+            creator_detail: { name: 'turbo477', real_name: 'Turbo' }
+          }
+        ]
+      })
+
+    const payload = await KdeConnect({ uri: kdeBugUri('341143') })
+
+    expect(scope.isDone()).to.equal(true)
+    expect(payload.bugs[0].summary).to.equal('Bring back per-virtual-desktop wallpapers')
+    expect(payload.bugs[0].is_open).to.equal(true)
+    expect(kdeStateToGitpay(payload.bugs[0])).to.equal('open')
+  })
+})


### PR DESCRIPTION
## Summary
Follow-up to GitLab import. #1098 asked for bugs.kde.org, with the example https://bugs.kde.org/show_bug.cgi?id=341143.

## What changed
- Parse `bugs.kde.org` `show_bug.cgi?id=` URLs and numeric `/341143` paths
- `KdeConnect` client for `GET /rest/bug/:id` (and the first comment for the description on import)
- Map Bugzilla `is_open` to gitpay `open`/`closed`
- Organization/project come from Bugzilla `product` / `component`
- KDE button on both import dialogs; pasting a bugs.kde.org URL selects KDE

## Tests
Mocha coverage of the parser plus a nock of the shipped `KdeConnect` client (11 passing).

Closes #1098