### PR TITLE
fix(auth): omit password hash from register and activate

### DIFF
--- a/src/app/controllers/user/user.ts
+++ b/src/app/controllers/user/user.ts
@@ -8,6 +8,7 @@ import * as task from '../../../modules/tasks'
 import Sendmail from '../../../mail/mail'
 import UserMail from '../../../mail/user'
 import i18n from 'i18n'
+import { omitRegisterSecrets } from '../../../utils/auth/omit-register-secrets'
 
 const models = Models as any
 
@@ -49,7 +50,7 @@ export const register = async (req: any, res: any) => {
     }
     try {
       const data = await user.userBuilds(req.body)
-      res.send(data)
+      res.send(omitRegisterSecrets(data))
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.log(error)
@@ -248,7 +249,7 @@ export const activateUser = async (req: any, res: any) => {
     if (foundUser.dataValues.email_verified) {
       // eslint-disable-next-line no-console
       console.log(`[activation] activate no-op: user ${userId} already verified`)
-      res.send(foundUser)
+      res.send(omitRegisterSecrets(foundUser))
       return
     }
 
@@ -280,7 +281,7 @@ export const activateUser = async (req: any, res: any) => {
     )
     // eslint-disable-next-line no-console
     console.log(`[activation] activate success for user ${userId}`)
-    res.send(userUpdate[1])
+    res.send(omitRegisterSecrets(userUpdate[1]))
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.log('[activation] activate error', error)
@@ -300,7 +301,7 @@ export const resendActivationEmail = async (req: any, res: any) => {
     if (foundUser.dataValues.email_verified) {
       // eslint-disable-next-line no-console
       console.log(`[activation] resend no-op: user ${userId} already verified`)
-      res.send(foundUser)
+      res.send(omitRegisterSecrets(foundUser))
       return
     }
 
@@ -329,7 +330,7 @@ export const resendActivationEmail = async (req: any, res: any) => {
       console.log(`[activation] resend sent for user ${userId}`)
       UserMail.activation(userUpdate[1].dataValues, token)
     }
-    res.send(userUpdate[1])
+    res.send(omitRegisterSecrets(userUpdate[1]))
   } catch (error: any) {
     // eslint-disable-next-line no-console
     console.log('[activation] resend error', error)

--- a/src/utils/auth/omit-register-secrets.ts
+++ b/src/utils/auth/omit-register-secrets.ts
@@ -1,0 +1,35 @@
+// Fields that must never go out on register/activate JSON. activation_token stays:
+// the client needs it to confirm the account.
+const OMITTED = new Set([
+  'password',
+  'paypal_id',
+  'customer_id',
+  'account_id',
+  'whop_account_id',
+  'recover_password_token',
+  'email_change_token',
+  'pending_email_change'
+])
+
+const isSequelizeInstance = (value: unknown): value is { get: (options: { plain: boolean }) => unknown; dataValues?: unknown } => {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { get?: unknown }).get === 'function' &&
+    !!(value as { dataValues?: unknown }).dataValues
+  )
+}
+
+export function omitRegisterSecrets<T>(value: T): T {
+  if (value == null || typeof value !== 'object') return value
+  const source = isSequelizeInstance(value) ? value.get({ plain: true }) : value
+  if (source == null || typeof source !== 'object' || Array.isArray(source)) {
+    return source as T
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, nested] of Object.entries(source as Record<string, unknown>)) {
+    if (OMITTED.has(key)) continue
+    out[key] = nested
+  }
+  return out as T
+}

--- a/test/api/user/userRegister.test.ts
+++ b/test/api/user/userRegister.test.ts
@@ -35,6 +35,8 @@ describe('POST /auth/register', () => {
       expect(res.body).to.exist
       expect(res.body.activation_token).to.exist
       expect(res.body.email_verified).to.equal(false)
+      expect(res.body).to.not.have.property('password')
+      expect(res.body).to.not.have.property('paypal_id')
     })
     it('shouldnt register with long names', async () => {
       const res = await agent

--- a/test/utils/auth/omit-register-secrets.test.ts
+++ b/test/utils/auth/omit-register-secrets.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai'
+import { omitRegisterSecrets } from '../../../src/utils/auth/omit-register-secrets'
+
+describe('omitRegisterSecrets', () => {
+  it('drops password hashes and payout ids but keeps activation_token', () => {
+    const sanitized = omitRegisterSecrets({
+      id: 8817,
+      email: 'user@example.com',
+      password: '$2b$08$examplehash',
+      activation_token: 'token-needed-to-confirm',
+      paypal_id: 'hidden',
+      customer_id: 'cus_hidden',
+      recover_password_token: 'reset'
+    })
+
+    expect(sanitized).to.deep.equal({
+      id: 8817,
+      email: 'user@example.com',
+      activation_token: 'token-needed-to-confirm'
+    })
+  })
+
+  it('plain-ifies sequelize-like instances', () => {
+    const instance = {
+      dataValues: {
+        id: 2,
+        email: 'a@b.c',
+        password: 'hash',
+        activation_token: 'tok'
+      },
+      get({ plain }: { plain: boolean }) {
+        expect(plain).to.equal(true)
+        return { ...this.dataValues }
+      }
+    }
+
+    expect(omitRegisterSecrets(instance)).to.deep.equal({
+      id: 2,
+      email: 'a@b.c',
+      activation_token: 'tok'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
`POST /auth/register` (and activate/resend) serialize the full User row, including `password` (bcrypt) and payout identifiers. The client only needs `activation_token` to confirm the account.

## What changed
- `omitRegisterSecrets` drops password hashes and payout/customer identifiers from those responses
- `activation_token` is kept so `/auth/activate` still works
- Register mocha coverage asserts the token is present and `password` is not

Companion to #1550 (public task fetch). This one is the signup path.

## Tests
- `test/utils/auth/omit-register-secrets.test.ts`
- extra assertions on `POST /auth/register` in `userRegister.test.ts`