### PR TITLE
fix(auth): stop public user search leaking payout identifiers

### DIFF
--- a/src/modules/users/userSearch.ts
+++ b/src/modules/users/userSearch.ts
@@ -1,26 +1,18 @@
 import Models from '../../models'
+import {
+  publicUserSearchAttributes,
+  publicUserSearchWhere
+} from '../../utils/auth/public-user-search'
 
 const models = Models as any
 
 export const userSearch = async (params: any) => {
   try {
+    const where = publicUserSearchWhere(params)
+    const attributes = publicUserSearchAttributes(where)
     const users = await models.User.findAll({
-      where: params || {},
-      attributes: [
-        'id',
-        'website',
-        'profile_url',
-        'picture_url',
-        'name',
-        'username',
-        'email',
-        'provider',
-        'account_id',
-        'paypal_id',
-        'repos',
-        'createdAt',
-        'updatedAt'
-      ],
+      where,
+      attributes,
       include: [models.Type]
     })
 

--- a/src/utils/auth/public-user-search.ts
+++ b/src/utils/auth/public-user-search.ts
@@ -1,0 +1,36 @@
+export const PUBLIC_USER_ATTRIBUTES = [
+  'id',
+  'website',
+  'profile_url',
+  'picture_url',
+  'name',
+  'username',
+  'provider',
+  'repos',
+  'createdAt',
+  'updatedAt'
+] as const
+
+// Reset-password looks up a user by token and shows email in the form copy.
+const RESET_LOOKUP_ATTRIBUTES = [...PUBLIC_USER_ATTRIBUTES, 'email'] as const
+
+export const ALLOWED_USER_SEARCH_FILTERS = ['id', 'username', 'recover_password_token'] as const
+
+export function publicUserSearchWhere(query: Record<string, unknown> | null | undefined) {
+  const where: Record<string, unknown> = {}
+  if (!query || typeof query !== 'object') return where
+  for (const key of ALLOWED_USER_SEARCH_FILTERS) {
+    const value = query[key]
+    if (value !== undefined && value !== null && value !== '') {
+      where[key] = value
+    }
+  }
+  return where
+}
+
+export function publicUserSearchAttributes(where: Record<string, unknown>) {
+  if (where.recover_password_token) {
+    return [...RESET_LOOKUP_ATTRIBUTES]
+  }
+  return [...PUBLIC_USER_ATTRIBUTES]
+}

--- a/test/api/user/userList.test.ts
+++ b/test/api/user/userList.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 import api from '../../../src/server'
 import Models from '../../../src/models'
 import { truncateModels } from '../../helpers'
+import { UserFactory } from '../../factories'
 
 const models = Models as any
 const agent = request.agent(api)
@@ -26,6 +27,49 @@ describe('GET /user', () => {
 
       expect(res.statusCode).to.equal(200)
       expect(res.body).to.exist
+    })
+
+    it('omits payout identifiers and email from the public user list', async () => {
+      await UserFactory({
+        name: 'Public User',
+        paypal_id: 'hidden-paypal',
+        account_id: 'acct_hidden',
+        email: 'hidden-user@example.com'
+      })
+
+      const res = await agent.get('/users').expect('Content-Type', /json/).expect(200)
+      expect(res.statusCode).to.equal(200)
+      expect(res.body).to.be.an('array').that.is.not.empty
+      const listed = res.body.find((row: any) => row.name === 'Public User')
+      expect(listed).to.exist
+      expect(listed).to.not.have.property('paypal_id')
+      expect(listed).to.not.have.property('account_id')
+      expect(listed).to.not.have.property('email')
+      expect(listed).to.not.have.property('password')
+      expect(listed.username).to.exist
+    })
+
+    it('includes email on a reset-token lookup but still omits payout identifiers', async () => {
+      const user = await UserFactory({
+        name: 'Reset User',
+        email: 'reset-user@example.com',
+        paypal_id: 'hidden-paypal-reset',
+        recover_password_token: 'reset-token-public-search'
+      })
+
+      const res = await agent
+        .get('/users')
+        .query({ recover_password_token: 'reset-token-public-search' })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      expect(res.body).to.be.an('array')
+      const listed = res.body.find((row: any) => row.id === user.id)
+      expect(listed).to.exist
+      expect(listed.email).to.equal('reset-user@example.com')
+      expect(listed).to.not.have.property('paypal_id')
+      expect(listed).to.not.have.property('account_id')
+      expect(listed).to.not.have.property('recover_password_token')
     })
   })
 })

--- a/test/utils/auth/public-user-search.test.ts
+++ b/test/utils/auth/public-user-search.test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai'
+import {
+  ALLOWED_USER_SEARCH_FILTERS,
+  PUBLIC_USER_ATTRIBUTES,
+  publicUserSearchAttributes,
+  publicUserSearchWhere
+} from '../../../src/utils/auth/public-user-search'
+
+describe('publicUserSearchWhere', () => {
+  it('keeps only id, username, and recover_password_token', () => {
+    expect(
+      publicUserSearchWhere({
+        id: '12',
+        username: 'leo',
+        recover_password_token: 'tok',
+        paypal_id: 'hidden',
+        email: 'hidden@example.com',
+        password: 'hash',
+        activation_token: 'act'
+      })
+    ).to.deep.equal({
+      id: '12',
+      username: 'leo',
+      recover_password_token: 'tok'
+    })
+  })
+
+  it('ignores empty values', () => {
+    expect(publicUserSearchWhere({ id: '', username: 'a' })).to.deep.equal({ username: 'a' })
+  })
+
+  it('returns an empty where for a dump of payout fields', () => {
+    expect(publicUserSearchWhere({ paypal_id: 'x', account_id: 'y' })).to.deep.equal({})
+  })
+})
+
+describe('publicUserSearchAttributes', () => {
+  it('omits payout and email fields on a public profile lookup', () => {
+    const attributes = publicUserSearchAttributes({ id: '1' })
+    expect(attributes).to.deep.equal([...PUBLIC_USER_ATTRIBUTES])
+    expect(attributes).to.not.include('paypal_id')
+    expect(attributes).to.not.include('email')
+    expect(attributes).to.not.include('account_id')
+    expect(attributes).to.not.include('password')
+  })
+
+  it('includes email only when looking up a reset token', () => {
+    const attributes = publicUserSearchAttributes({ recover_password_token: 'tok' })
+    expect(attributes).to.include('email')
+    expect(attributes).to.not.include('paypal_id')
+    expect(attributes).to.not.include('account_id')
+  })
+
+  it('documents the allow-listed filters', () => {
+    expect([...ALLOWED_USER_SEARCH_FILTERS]).to.deep.equal([
+      'id',
+      'username',
+      'recover_password_token'
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
`GET /users` is public. `userSearch` passed `req.query` straight into `User.findAll` and selected `paypal_id`, `email`, and `account_id`. A request with no query currently returns every user, including payout identifiers.

Companion to #1550 (task fetch) and #1554 (register). This is the user directory.

## What changed
- Allow-list filters: `id`, `username`, `recover_password_token`
- Public attributes no longer include `paypal_id` or `account_id`
- Email is returned only on a `recover_password_token` lookup, which the reset-password page displays

## Tests
- `test/utils/auth/public-user-search.test.ts` covers the shipped allow-list
- `test/api/user/userList.test.ts` hits `GET /users` and a reset-token lookup