### PR TITLE
fix(auth): require a session on transfers and strip nested user secrets

### DIFF
--- a/src/app/controllers/transfer.ts
+++ b/src/app/controllers/transfer.ts
@@ -19,9 +19,29 @@ export const updateTransfer = async (req: any, res: any) => {
   }
 }
 
+const ownsTransferQuery = (query: any, userId: number) => {
+  const uid = Number(userId)
+  const requestedUserId = query.userId != null ? Number(query.userId) : undefined
+  const requestedTo = query.to != null ? Number(query.to) : undefined
+  if (requestedUserId != null && requestedUserId !== uid) return null
+  if (requestedTo != null && requestedTo !== uid) return null
+  if (requestedUserId == null && requestedTo == null) {
+    return { userId: uid }
+  }
+  return {
+    ...(requestedUserId != null ? { userId: requestedUserId } : {}),
+    ...(requestedTo != null ? { to: requestedTo } : {})
+  }
+}
+
 export const searchTransfer = async (req: any, res: any) => {
   try {
-    const data = await Transfer.transferSearch(req.query)
+    const scoped = ownsTransferQuery(req.query, req.user.id)
+    if (!scoped) {
+      res.send([])
+      return
+    }
+    const data = await Transfer.transferSearch(scoped)
     res.send(data)
   } catch (error: any) {
     // eslint-disable-next-line no-console
@@ -33,6 +53,17 @@ export const searchTransfer = async (req: any, res: any) => {
 export const fetchTransfer = async (req: any, res: any) => {
   try {
     const data = await Transfer.transferFetch(req.params.id)
+    if (!data) {
+      res.status(404).send({ error: 'not_found' })
+      return
+    }
+    const uid = Number(req.user.id)
+    const ownerId = Number(data.userId ?? data.dataValues?.userId)
+    const destinationId = Number(data.to ?? data.dataValues?.to)
+    if (uid !== ownerId && uid !== destinationId) {
+      res.status(403).send({ errors: ['Forbidden'] })
+      return
+    }
     res.send(data)
   } catch (error: any) {
     // eslint-disable-next-line no-console

--- a/src/app/routes/transfer.ts
+++ b/src/app/routes/transfer.ts
@@ -1,11 +1,13 @@
 import express from 'express'
 import * as authenticationHelpers from '../../utils/auth/authenticationHelpers'
 import * as controllers from '../controllers/transfer'
+import secure from './secure'
 
 void authenticationHelpers
 
 const router = express.Router()
 
+router.use(secure)
 router.post('/create', controllers.createTransfer)
 router.get('/search', controllers.searchTransfer)
 router.put('/update', controllers.updateTransfer)

--- a/src/queries/transfer/findTransferByIdForFetch.ts
+++ b/src/queries/transfer/findTransferByIdForFetch.ts
@@ -1,4 +1,5 @@
 import Models from '../../models'
+import { publicUserInclude } from '../../utils/auth/user-secret-attributes'
 
 const models = Models as any
 
@@ -7,14 +8,8 @@ export const findTransferByIdForFetch = async (id: number, options: any = {}) =>
     where: { id },
     include: [
       models.Task,
-      {
-        model: models.User,
-        as: 'User'
-      },
-      {
-        model: models.User,
-        as: 'destination'
-      }
+      publicUserInclude(models.User, 'User'),
+      publicUserInclude(models.User, 'destination')
     ],
     ...options
   })

--- a/src/queries/transfer/searchTransfers.ts
+++ b/src/queries/transfer/searchTransfers.ts
@@ -1,4 +1,5 @@
 import Models from '../../models'
+import { publicUserInclude } from '../../utils/auth/user-secret-attributes'
 
 const models = Models as any
 
@@ -9,30 +10,19 @@ type TransferSearchParams = {
 
 export async function searchTransfers(params: TransferSearchParams = {}) {
   let transfers: any[] = []
+  const userInclude = publicUserInclude(models.User, 'User')
   if (params.userId) {
     transfers = await models.Transfer.findAll({
       where: { userId: params.userId },
       order: [['createdAt', 'DESC']],
-      include: [
-        models.Task,
-        {
-          model: models.User,
-          as: 'User'
-        }
-      ]
+      include: [models.Task, userInclude]
     })
   }
   if (params.to) {
     transfers = await models.Transfer.findAll({
       where: { to: params.to },
       order: [['createdAt', 'DESC']],
-      include: [
-        models.Task,
-        {
-          model: models.User,
-          as: 'User'
-        }
-      ]
+      include: [models.Task, userInclude]
     })
   }
   return transfers

--- a/src/utils/auth/user-secret-attributes.ts
+++ b/src/utils/auth/user-secret-attributes.ts
@@ -1,0 +1,17 @@
+export const USER_SECRET_ATTRIBUTES = [
+  'password',
+  'recover_password_token',
+  'activation_token',
+  'email_change_token',
+  'paypal_id',
+  'customer_id',
+  'account_id',
+  'whop_account_id',
+  'pending_email_change'
+] as const
+
+export const publicUserInclude = (UserModel: unknown, as?: string) => ({
+  model: UserModel,
+  ...(as ? { as } : {}),
+  attributes: { exclude: [...USER_SECRET_ATTRIBUTES] }
+})

--- a/test/api/transfer/transfer.test.ts
+++ b/test/api/transfer/transfer.test.ts
@@ -21,19 +21,49 @@ import { get as paypalGetPayoutSample } from '../../data/paypal/paypal.payout'
 
 const agent = request.agent(api)
 
+let lastAuth = ''
+
+const makeTask = async (...args: any[]) => {
+  const result = await createTask(agent, ...args)
+  lastAuth = result?.headers?.authorization || ''
+  return result
+}
+
+const withAuth = (req: any) => {
+  if (lastAuth) return req.set('Authorization', lastAuth)
+  return req
+}
+
 // Common function to create transfer
 const createTransferWithTaskData = async (
   taskData: any,
   userId?: number,
   transferId?: string
 ): Promise<any> => {
-  const res = await agent.post('/transfers/create').send({
+  const res = await withAuth(agent.post('/transfers/create')).send({
     taskId: taskData.id,
     userId: userId,
     transfer_id: transferId
   })
   return res
 }
+
+describe('GET /transfers without a session', () => {
+  it('rejects unauthenticated search', async () => {
+    const res = await agent.get('/transfers/search').query({ userId: 1 })
+    expect(res.statusCode).to.equal(403)
+  })
+
+  it('rejects unauthenticated fetch', async () => {
+    const res = await agent.get('/transfers/fetch/1')
+    expect(res.statusCode).to.equal(403)
+  })
+
+  it('rejects unauthenticated create', async () => {
+    const res = await agent.post('/transfers/create').send({ taskId: 1 })
+    expect(res.statusCode).to.equal(403)
+  })
+})
 
 describe('POST /transfer', () => {
   describe('Initial transfer with one credit card and account activated', () => {
@@ -49,7 +79,7 @@ describe('POST /transfer', () => {
     })
     it('should not create transfer with no orders', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const assign = await createAssign(agent, { taskId: taskData.id })
         const res = await createTransferWithTaskData(taskData, taskData.userId)
@@ -62,7 +92,7 @@ describe('POST /transfer', () => {
     })
     it('should not create a transfer with no user assigned', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const res = await createTransferWithTaskData(taskData, taskData.userId)
         expect(res.body).to.exist
@@ -74,7 +104,7 @@ describe('POST /transfer', () => {
     })
     it('should not create transfer with no paid order', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({ userId: taskData.userId, TaskId: taskData.id })
         const assign = await createAssign(agent, { taskId: taskData.id })
@@ -89,7 +119,7 @@ describe('POST /transfer', () => {
     it('should create transfer with a single order paid with stripe', async () => {
       try {
         nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({
           userId: taskData.userId,
@@ -113,7 +143,7 @@ describe('POST /transfer', () => {
     it('should create transfer with two orders paid with stripe', async () => {
       try {
         nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({
           userId: taskData.userId,
@@ -143,7 +173,7 @@ describe('POST /transfer', () => {
     it('should create transfer with three multiple orders paid with stripe', async () => {
       try {
         nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({
           userId: taskData.userId,
@@ -178,7 +208,7 @@ describe('POST /transfer', () => {
     })
     it('should create transfer with three multiple orders paid with stripe and paypal but paypal not paid', async () => {
       nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -240,7 +270,7 @@ describe('POST /transfer', () => {
           }
         )
 
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -283,7 +313,7 @@ describe('POST /transfer', () => {
     it('should update transfer pending to created for a pending transfer for an activated account', async () => {
       nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
       nock('https://api.stripe.com').persist().get('/v1/transfers').reply(200, transfer)
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -293,7 +323,7 @@ describe('POST /transfer', () => {
       })
       const assign = await createAssign(agent, { taskId: taskData.id })
       const transferData = await createTransferWithTaskData(taskData, taskData.userId)
-      const res = await agent.put('/transfers/update').send({
+      const res = await withAuth(agent.put('/transfers/update')).send({
         id: transferData.body.id
       })
       expect(res.status).to.equal(200)
@@ -345,7 +375,7 @@ describe('POST /transfer', () => {
 
       nock('https://api.stripe.com').persist().get('/v1/transfers').reply(200, transfer)
 
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -371,7 +401,7 @@ describe('POST /transfer', () => {
           }
         }
       )
-      const res = await agent.put('/transfers/update').send({
+      const res = await withAuth(agent.put('/transfers/update')).send({
         id: transferData.body.id
       })
       expect(res.status).to.equal(200)
@@ -421,7 +451,7 @@ describe('POST /transfer', () => {
       })
       nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
       nock('https://api.stripe.com').persist().get('/v1/transfers').reply(200, transfer)
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -437,7 +467,7 @@ describe('POST /transfer', () => {
       })
       const assign = await createAssign(agent, { taskId: taskData.id }, { paypal_id: 'foo' })
       const transferData = await createTransferWithTaskData(taskData, taskData.userId)
-      const res = await agent.put('/transfers/update').send({
+      const res = await withAuth(agent.put('/transfers/update')).send({
         id: transferData.body.id
       })
       expect(res.status).to.equal(200)
@@ -449,7 +479,7 @@ describe('POST /transfer', () => {
       expect(res.body.transfer_id).to.equal('tr_1CcGcaBrSjgsps2DGToaoNF5')
     })
     it('should search transfers', async () => {
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({ userId: taskData.userId, TaskId: taskData.id })
       const assign = await createAssign(agent, { taskId: taskData.id })
@@ -458,14 +488,18 @@ describe('POST /transfer', () => {
         userId: taskData.userId,
         to: assign.userId
       })
-      const res = await agent.get('/transfers/search').query({ userId: taskData.userId })
+      const res = await withAuth(agent.get('/transfers/search')).query({ userId: taskData.userId })
       expect(res.body).to.exist
       expect(res.body.length).to.equal(1)
+      if (res.body[0].User) {
+        expect(res.body[0].User).to.not.have.property('password')
+        expect(res.body[0].User).to.not.have.property('paypal_id')
+      }
     })
     it('should fetch transfer', async () => {
       nock('https://api.stripe.com').persist().get('/v1/transfers/1234').reply(200, transfer)
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({ userId: taskData.userId, TaskId: taskData.id })
         const assign = await createAssign(agent, { taskId: taskData.id })
@@ -475,7 +509,7 @@ describe('POST /transfer', () => {
           to: assign.userId
         })
         const transferId = transfer.id
-        const res = await agent.get('/transfers/fetch/' + transferId)
+        const res = await withAuth(agent.get('/transfers/fetch/' + transferId))
         expect(res.body).to.exist
         expect(res.body.id).to.equal(transferId)
       } catch (e) {
@@ -534,7 +568,7 @@ describe('POST /transfer', () => {
         'Content-Type': 'application/json'
       })
 
-      const task = await createTask(agent)
+      const task = await makeTask()
       const { body: taskData } = task
       const order = await createOrder({
         userId: taskData.userId,
@@ -560,7 +594,7 @@ describe('POST /transfer', () => {
         { paypal_id: 'foo@example.com' }
       )
       const createTransfer = await createTransferWithTaskData(taskData, taskData.userId)
-      const res = await agent.get('/transfers/fetch/' + createTransfer.body.id)
+      const res = await withAuth(agent.get('/transfers/fetch/' + createTransfer.body.id))
       expect(res.body).to.exist
       expect(res.body.status).to.equal('in_transit')
       expect(res.body.value).to.equal('400')
@@ -581,7 +615,7 @@ describe('POST /transfer', () => {
     })
     it('should not create transfers with same id', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({
           userId: taskData.userId,
@@ -601,7 +635,7 @@ describe('POST /transfer', () => {
     it('should not create transfers with same taskId', async () => {
       try {
         nock('https://api.stripe.com').persist().post('/v1/transfers').reply(200, transfer)
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         const order = await createOrder({
           userId: taskData.userId,
@@ -620,7 +654,7 @@ describe('POST /transfer', () => {
     })
     it('should create pending transfer when assigned user has no Stripe account_id', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         await createOrder({
           userId: taskData.userId,
@@ -654,7 +688,7 @@ describe('POST /transfer', () => {
             message: 'This account does not have the capability to transfer funds.'
           }
         })
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         await createOrder({
           userId: taskData.userId,
@@ -676,7 +710,7 @@ describe('POST /transfer', () => {
     })
     it('should create pending transfer for PayPal-only payment when user has no paypal_id', async () => {
       try {
-        const task = await createTask(agent)
+        const task = await makeTask()
         const { body: taskData } = task
         await createOrder({
           userId: taskData.userId,

--- a/test/utils/auth/user-secret-attributes.test.ts
+++ b/test/utils/auth/user-secret-attributes.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import {
+  USER_SECRET_ATTRIBUTES,
+  publicUserInclude
+} from '../../../src/utils/auth/user-secret-attributes'
+
+describe('publicUserInclude', () => {
+  it('excludes credential attributes from sequelize User includes', () => {
+    const User = { name: 'User' }
+    expect(publicUserInclude(User, 'destination')).to.deep.equal({
+      model: User,
+      as: 'destination',
+      attributes: { exclude: [...USER_SECRET_ATTRIBUTES] }
+    })
+  })
+
+  it('omits password hashes and payout identifiers', () => {
+    expect([...USER_SECRET_ATTRIBUTES]).to.include.members([
+      'password',
+      'paypal_id',
+      'account_id',
+      'customer_id',
+      'activation_token'
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
`GET /transfers/search?userId=` and `GET /transfers/fetch/:id` are unauthenticated. They include the related `User` (and `destination`) with password hashes, recovery tokens, and payout identifiers. Create and update were also public.

Companion to #1550 (task fetch) and #1555 (user directory). This is the payout ledger.

## What changed
- `secure` on every `/transfers` route
- Search only returns transfers for the logged-in user (`userId` or `to`)
- Fetch 403s unless the caller is the sender or recipient
- Sequelize User includes exclude credential attributes

## Tests
- Unauthenticated search/fetch/create return 403
- Existing transfer mocha coverage now sends the session from `createTask`
- `publicUserInclude` unit coverage