### PR TITLE
fix(auth): strip user secrets from remaining public list endpoints

### DIFF
--- a/src/modules/organizations/organizationList.ts
+++ b/src/modules/organizations/organizationList.ts
@@ -1,4 +1,5 @@
 import models from '../../models'
+import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
 
 const currentModels = models as any
 
@@ -11,7 +12,8 @@ export async function organizationList(params?: any) {
           include: [currentModels.Organization]
         },
         {
-          model: currentModels.User
+          model: currentModels.User,
+          attributes: { exclude: USER_SENSITIVE_ATTRIBUTES }
         }
       ]
     })

--- a/src/modules/projects/projectFetch.ts
+++ b/src/modules/projects/projectFetch.ts
@@ -1,4 +1,5 @@
 import models from '../../models'
+import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
 
 const currentModels = models as any
 
@@ -16,7 +17,11 @@ export async function projectFetch(projectParams: ProjectFetchParams, params?: a
         {
           model: currentModels.Task,
           where: params || null,
-          include: [currentModels.Project, currentModels.User, currentModels.Assign]
+          include: [
+            currentModels.Project,
+            { model: currentModels.User, attributes: { exclude: USER_SENSITIVE_ATTRIBUTES } },
+            currentModels.Assign
+          ]
         },
         currentModels.Organization
       ]

--- a/src/modules/projects/projectList.ts
+++ b/src/modules/projects/projectList.ts
@@ -1,4 +1,5 @@
 import models from '../../models'
+import { USER_SENSITIVE_ATTRIBUTES } from '../../queries/user/userSensitiveAttributes'
 
 const currentModels = models as any
 
@@ -9,7 +10,12 @@ export async function projectList(params?: any) {
         currentModels.Organization,
         {
           model: currentModels.Task,
-          include: [currentModels.User]
+          include: [
+            {
+              model: currentModels.User,
+              attributes: { exclude: USER_SENSITIVE_ATTRIBUTES }
+            }
+          ]
         }
       ]
     })

--- a/src/modules/users/userSearch.ts
+++ b/src/modules/users/userSearch.ts
@@ -1,26 +1,18 @@
 import Models from '../../models'
+import {
+  publicUserSearchAttributes,
+  publicUserSearchWhere
+} from '../../utils/auth/public-user-search'
 
 const models = Models as any
 
 export const userSearch = async (params: any) => {
   try {
+    const where = publicUserSearchWhere(params)
+    const attributes = publicUserSearchAttributes(where)
     const users = await models.User.findAll({
-      where: params || {},
-      attributes: [
-        'id',
-        'website',
-        'profile_url',
-        'picture_url',
-        'name',
-        'username',
-        'email',
-        'provider',
-        'account_id',
-        'paypal_id',
-        'repos',
-        'createdAt',
-        'updatedAt'
-      ],
+      where,
+      attributes,
       include: [models.Type]
     })
 

--- a/src/utils/auth/public-user-search.ts
+++ b/src/utils/auth/public-user-search.ts
@@ -1,0 +1,36 @@
+export const PUBLIC_USER_ATTRIBUTES = [
+  'id',
+  'website',
+  'profile_url',
+  'picture_url',
+  'name',
+  'username',
+  'provider',
+  'repos',
+  'createdAt',
+  'updatedAt'
+] as const
+
+// Reset-password looks up a user by token and shows email in the form copy.
+const RESET_LOOKUP_ATTRIBUTES = [...PUBLIC_USER_ATTRIBUTES, 'email'] as const
+
+export const ALLOWED_USER_SEARCH_FILTERS = ['id', 'username', 'recover_password_token'] as const
+
+export function publicUserSearchWhere(query: Record<string, unknown> | null | undefined) {
+  const where: Record<string, unknown> = {}
+  if (!query || typeof query !== 'object') return where
+  for (const key of ALLOWED_USER_SEARCH_FILTERS) {
+    const value = query[key]
+    if (value !== undefined && value !== null && value !== '') {
+      where[key] = value
+    }
+  }
+  return where
+}
+
+export function publicUserSearchAttributes(where: Record<string, unknown>) {
+  if (where.recover_password_token) {
+    return [...RESET_LOOKUP_ATTRIBUTES]
+  }
+  return [...PUBLIC_USER_ATTRIBUTES]
+}

--- a/test/api/user/userList.test.ts
+++ b/test/api/user/userList.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 import api from '../../../src/server'
 import Models from '../../../src/models'
 import { truncateModels } from '../../helpers'
+import { UserFactory } from '../../factories'
 
 const models = Models as any
 const agent = request.agent(api)
@@ -26,6 +27,49 @@ describe('GET /user', () => {
 
       expect(res.statusCode).to.equal(200)
       expect(res.body).to.exist
+    })
+
+    it('omits payout identifiers and email from the public user list', async () => {
+      await UserFactory({
+        name: 'Public User',
+        paypal_id: 'hidden-paypal',
+        account_id: 'acct_hidden',
+        email: 'hidden-user@example.com'
+      })
+
+      const res = await agent.get('/users').expect('Content-Type', /json/).expect(200)
+      expect(res.statusCode).to.equal(200)
+      expect(res.body).to.be.an('array').that.is.not.empty
+      const listed = res.body.find((row: any) => row.name === 'Public User')
+      expect(listed).to.exist
+      expect(listed).to.not.have.property('paypal_id')
+      expect(listed).to.not.have.property('account_id')
+      expect(listed).to.not.have.property('email')
+      expect(listed).to.not.have.property('password')
+      expect(listed.username).to.exist
+    })
+
+    it('includes email on a reset-token lookup but still omits payout identifiers', async () => {
+      const user = await UserFactory({
+        name: 'Reset User',
+        email: 'reset-user@example.com',
+        paypal_id: 'hidden-paypal-reset',
+        recover_password_token: 'reset-token-public-search'
+      })
+
+      const res = await agent
+        .get('/users')
+        .query({ recover_password_token: 'reset-token-public-search' })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      expect(res.body).to.be.an('array')
+      const listed = res.body.find((row: any) => row.id === user.id)
+      expect(listed).to.exist
+      expect(listed.email).to.equal('reset-user@example.com')
+      expect(listed).to.not.have.property('paypal_id')
+      expect(listed).to.not.have.property('account_id')
+      expect(listed).to.not.have.property('recover_password_token')
     })
   })
 })

--- a/test/utils/auth/public-user-search.test.ts
+++ b/test/utils/auth/public-user-search.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai'
+import {
+  ALLOWED_USER_SEARCH_FILTERS,
+  PUBLIC_USER_ATTRIBUTES,
+  publicUserSearchAttributes,
+  publicUserSearchWhere
+} from '../../../src/utils/auth/public-user-search'
+import { USER_SENSITIVE_ATTRIBUTES } from '../../../src/queries/user/userSensitiveAttributes'
+import fs from 'fs'
+import path from 'path'
+
+describe('publicUserSearchWhere', () => {
+  it('keeps only id, username, and recover_password_token', () => {
+    expect(
+      publicUserSearchWhere({
+        id: '12',
+        username: 'leo',
+        recover_password_token: 'tok',
+        paypal_id: 'hidden',
+        email: 'hidden@example.com',
+        password: 'hash',
+        activation_token: 'act'
+      })
+    ).to.deep.equal({
+      id: '12',
+      username: 'leo',
+      recover_password_token: 'tok'
+    })
+  })
+
+  it('returns an empty where for a dump of payout fields', () => {
+    expect(publicUserSearchWhere({ paypal_id: 'x', account_id: 'y' })).to.deep.equal({})
+  })
+})
+
+describe('publicUserSearchAttributes', () => {
+  it('omits payout and email fields on a public profile lookup', () => {
+    const attributes = publicUserSearchAttributes({ id: '1' })
+    expect(attributes).to.deep.equal([...PUBLIC_USER_ATTRIBUTES])
+    expect(attributes).to.not.include('paypal_id')
+    expect(attributes).to.not.include('email')
+    expect(attributes).to.not.include('account_id')
+    expect(attributes).to.not.include('password')
+  })
+
+  it('includes email only when looking up a reset token', () => {
+    const attributes = publicUserSearchAttributes({ recover_password_token: 'tok' })
+    expect(attributes).to.include('email')
+    expect(attributes).to.not.include('paypal_id')
+  })
+
+  it('documents the allow-listed filters', () => {
+    expect([...ALLOWED_USER_SEARCH_FILTERS]).to.deep.equal([
+      'id',
+      'username',
+      'recover_password_token'
+    ])
+  })
+})
+
+describe('remaining public list endpoints', () => {
+  const read = (rel: string) =>
+    fs.readFileSync(path.join(__dirname, '../../../', rel), 'utf8')
+
+  it('organizationList excludes USER_SENSITIVE_ATTRIBUTES on the nested User', () => {
+    const src = read('src/modules/organizations/organizationList.ts')
+    expect(src).to.include('USER_SENSITIVE_ATTRIBUTES')
+    expect(src).to.include('exclude:')
+    expect(USER_SENSITIVE_ATTRIBUTES).to.include.members(['password', 'paypal_id'])
+  })
+
+  it('projectList and projectFetch exclude USER_SENSITIVE_ATTRIBUTES on Task.User', () => {
+    const listSrc = read('src/modules/projects/projectList.ts')
+    const fetchSrc = read('src/modules/projects/projectFetch.ts')
+    expect(listSrc).to.include('USER_SENSITIVE_ATTRIBUTES')
+    expect(fetchSrc).to.include('USER_SENSITIVE_ATTRIBUTES')
+  })
+})


### PR DESCRIPTION
## Summary
`20d19c3` closed the public task/transfer User dumps. These unauthenticated list endpoints still return nested `User` rows with password hashes and payout identifiers:

- `GET /users` (also forwards `req.query` into `User.findAll`, so `paypal_id` works as a filter)
- `GET /organizations/list` (`include: User` with no attribute restriction)
- `GET /projects/list` and `GET /projects/fetch/:id` (`Task.User` unrestricted)

Follow-up to #1550 / #1555 / #1559. #1555 covered `/users` against the previous master; this rebases that fix onto current master and covers the org/project lists too.

## What changed
- User search allow-lists `id`, `username`, `recover_password_token`
- Public directory attributes omit `paypal_id`, `account_id`, `email` (email stays on reset-token lookup)
- Organization and project list/fetch User includes use `USER_SENSITIVE_ATTRIBUTES`

## Tests
- `test/utils/auth/public-user-search.test.ts`
- extra `GET /users` cases in `userList.test.ts`