### PR TITLE
fix: handle task solution request failures without throwing

### DIFF
--- a/frontend/src/actions/taskSolutionActions.js
+++ b/frontend/src/actions/taskSolutionActions.js
@@ -104,7 +104,7 @@ const fetchPullRequestData = (owner, repositoryName, pullRequestId, taskId) => {
         return dispatch(fetchPullRequestDataSuccess(response.data))
       })
       .catch((error) => {
-        if (error.response.data && error.response.data.error) {
+        if (error?.response?.data?.error) {
           dispatch(addNotification(ERRORS[error.response.data.error], { severity: 'error' }))
           return dispatch(fetchPullRequestDataError(error.response.data.error))
         }
@@ -112,9 +112,7 @@ const fetchPullRequestData = (owner, repositoryName, pullRequestId, taskId) => {
         dispatch(
           addNotification(ERRORS['COULD_NOT_FETCH_PULL_REQUEST_DATA'], { severity: 'error' })
         )
-        return dispatch(
-          getTaskSolutionError(JSON.parse(ERRORS['COULD_NOT_FETCH_PULL_REQUEST_DATA']))
-        )
+        return dispatch(fetchPullRequestDataError(error))
       })
   }
 }
@@ -139,7 +137,7 @@ const createTaskSolution = (taskSolution) => {
         return dispatch(createTaskSolutionSuccess(response.data))
       })
       .catch((error) => {
-        if (error.response.data && error.response.data.error) {
+        if (error?.response?.data?.error) {
           dispatch(
             addNotification(ERRORS[error.response.data.error] || error.response.data.error, {
               extra: '',
@@ -153,7 +151,7 @@ const createTaskSolution = (taskSolution) => {
         }
 
         dispatch(addNotification(ERRORS['COULD_NOT_CREATE_TASK_SOLUTION'], { severity: 'error' }))
-        return dispatch(getTaskSolutionError(JSON.parse(ERRORS['COULD_NOT_CREATE_TASK_SOLUTION'])))
+        return dispatch(createTaskSolutionError(error))
       })
   }
 }
@@ -185,13 +183,13 @@ const updateTaskSolution = ({ taskSolutionId, pullRequestURL, taskId }) => {
         return dispatch(updateTaskSolutionSuccess(response.data))
       })
       .catch((error) => {
-        if (error.response.data && error.response.data.error) {
+        if (error?.response?.data?.error) {
           dispatch(addNotification(ERRORS[error.response.data.error], { severity: 'error' }))
           return dispatch(updateTaskSolutionError(error.response.data.error))
         }
 
         dispatch(addNotification(ERRORS['COULD_NOT_UPDATE_TASK_SOLUTION'], { severity: 'error' }))
-        return dispatch(getTaskSolutionError(JSON.parse(ERRORS['COULD_NOT_UPDATE_TASK_SOLUTION'])))
+        return dispatch(updateTaskSolutionError(error))
       })
   }
 }

--- a/frontend/tests/actions/taskSolutionActions/taskSolutionErrors.test.js
+++ b/frontend/tests/actions/taskSolutionActions/taskSolutionErrors.test.js
@@ -1,0 +1,81 @@
+import axios from 'axios'
+import configureMockStore from 'redux-mock-store'
+import { thunk } from 'redux-thunk'
+import {
+  fetchPullRequestData,
+  createTaskSolution,
+  updateTaskSolution
+} from '../../../src/actions/taskSolutionActions'
+
+jest.mock('axios')
+jest.mock('../../../src/actions/helpers', () => ({ validToken: jest.fn() }))
+jest.mock('../../../src/actions/taskActions', () => ({
+  fetchTask: (id) => ({ type: 'REFRESH_TASK', id })
+}))
+
+const mockStore = configureMockStore([thunk])
+const operations = [
+  ['FETCH_PULL_REQUEST_DATA', 'get', () => fetchPullRequestData('owner', 'repo', 2, 1), 'fetch'],
+  ['CREATE_TASK_SOLUTION', 'post', () => createTaskSolution({ taskId: 1 }), 'create'],
+  [
+    'UPDATE_TASK_SOLUTION',
+    'patch',
+    () =>
+      updateTaskSolution({
+        taskSolutionId: 3,
+        taskId: 1,
+        pullRequestURL: 'https://github.com/owner/repo/pull/2'
+      }),
+    'update'
+  ]
+]
+
+describe.each(operations)('%s error handling', (type, method, action, notification) => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it.each([
+    ['network failure', new Error('Network Error')],
+    ['timeout', Object.assign(new Error('timeout'), { code: 'ECONNABORTED' })],
+    ['missing response body', { response: { status: 500 } }],
+    ['null response body', { response: { status: 500, data: null } }],
+    ['unstructured response body', { response: { status: 502, data: 'Bad Gateway' } }]
+  ])('reports a %s without throwing from the rejection handler', async (_name, error) => {
+    axios[method].mockRejectedValueOnce(error)
+    const store = mockStore({ intl: { messages: {} } })
+
+    await expect(store.dispatch(action())).resolves.toEqual({
+      type: `${type}_ERROR`,
+      completed: true,
+      error
+    })
+    expect(store.getActions()).toEqual([
+      { type: `${type}_REQUESTED`, completed: false },
+      {
+        type: 'ADD_NOTIFICATION',
+        open: true,
+        text: `issue.solution.dialog.${notification}.error`,
+        severity: 'error',
+        link: undefined
+      },
+      { type: `${type}_ERROR`, completed: true, error }
+    ])
+  })
+
+  it('preserves the mapped server error', async () => {
+    axios[method].mockRejectedValueOnce({ response: { data: { error: 'PULL_REQUEST_NOT_FOUND' } } })
+    const store = mockStore({ intl: { messages: {} } })
+
+    await expect(store.dispatch(action())).resolves.toEqual({
+      type: `${type}_ERROR`,
+      completed: true,
+      error: 'PULL_REQUEST_NOT_FOUND'
+    })
+    expect(store.getActions()).toContainEqual(
+      expect.objectContaining({
+        type: 'ADD_NOTIFICATION',
+        text: 'issue.solution.dialog.pullRequest.notFound',
+        severity: 'error'
+      })
+    )
+  })
+})


### PR DESCRIPTION
When fetching a pull request or creating/updating a task solution fails with a network error or timeout, the rejection handler dereferences `error.response.data` and throws a second exception. Responses without a structured error also reach `JSON.parse` on a translation key, which throws instead of dispatching the operation's error action.

This change safely checks for the server error, preserves existing mapped-error behavior, and dispatches the matching fetch/create/update error action with the original error for fallback failures. It includes 18 regression cases covering network failures, timeouts, missing/null/unstructured response bodies, and mapped server errors.

Validation on Windows with Node 24.19.0:
- Before the fix: 15 regression cases failed and 3 passed.
- After the fix: full frontend Jest suite passed (78 passed, 26 skipped; 13 passing suites, 4 skipped).
- ESLint passed for both changed files; formatted with the repository's Prettier configuration.
- No live payment/API requests were used; Axios is mocked in the regression tests. Backend and end-to-end suites were not run.

Funding inquiry: would the project consider a US$25 bounty for this fix? This is a new funding request, not a claim against an already funded issue. Please confirm eligibility and the payout process before any payment request is created.

This contribution was developed with AI assistance and verified with the tests above.