### PR TITLE
fix: preserve zero-decimal currency precision in amount conversion

### DIFF
--- a/src/utils/amount/handle-amount.ts
+++ b/src/utils/amount/handle-amount.ts
@@ -14,7 +14,7 @@ export function calculateAmountWithPercent(
   type: string,
   currency: string = 'usd'
 ): HandleAmountResult {
-  const decimalPlaces = currencyInfo[currency.toLowerCase()]?.decimalPlaces || 2
+  const decimalPlaces = currencyInfo[currency.toLowerCase()]?.decimalPlaces ?? 2
   const centsFactor = Math.pow(10, decimalPlaces)
   let decimalAmount: any
 

--- a/test/handle-amount.test.ts
+++ b/test/handle-amount.test.ts
@@ -2,6 +2,28 @@ import { expect } from 'chai'
 import { calculateAmountWithPercent } from '../src/utils'
 
 describe('Amount Conversion', () => {
+  for (const currency of ['jpy', 'JPY', 'krw', 'clp', 'vnd', 'xaf', 'xof', 'vuv', 'xpf', 'rwf']) {
+    for (const type of ['centavos', 'decimal']) {
+      it(`should preserve whole units for ${currency} in ${type} mode`, () => {
+        expect(calculateAmountWithPercent(1000, 8, type, currency)).to.deep.equal({
+          centavos: 920,
+          decimal: 920,
+          decimalFee: 80,
+          centavosFee: 80
+        })
+      })
+    }
+  }
+
+  it('should retain the two-decimal fallback for an unknown currency', () => {
+    expect(calculateAmountWithPercent(1000, 8, 'centavos', 'unknown')).to.deep.equal({
+      centavos: 920,
+      decimal: 9.2,
+      decimalFee: 0.8,
+      centavosFee: 80
+    })
+  })
+
   it('should convert cents to decimal', () => {
     const result = calculateAmountWithPercent(100, 0, 'centavos')
     expect(result.centavos).to.equal(100)

--- a/test/services/paymentRequest/sellerNetAmount.test.ts
+++ b/test/services/paymentRequest/sellerNetAmount.test.ts
@@ -2,6 +2,18 @@ import { expect } from 'chai'
 import { computeSellerNetAmount } from '../../../src/services/paymentRequest/sellerNetAmount'
 
 describe('computeSellerNetAmount', () => {
+  it('keeps the seller net amount in whole yen for a zero-decimal currency', () => {
+    const result = computeSellerNetAmount({
+      paymentRequestPayment: { amount: 1000 },
+      paymentRequest: { amount: 1000, custom_amount: false, provider: 'stripe' },
+      currency: 'jpy'
+    })
+
+    expect(result.originalAmountDecimal).to.equal(1000)
+    expect(result.netAmountDecimal).to.equal(920)
+    expect(result.netAmountCents).to.equal(920)
+  })
+
   it('applies Gitpay\'s 8% cut on top of Whop\'s reported net for a legacy (transfer) payment', () => {
     const result = computeSellerNetAmount({
       paymentRequestPayment: {


### PR DESCRIPTION
The amount conversion helper replaces a valid zero decimal precision with the two-decimal fallback. For 1,000 JPY with an 8% fee, converting a decimal amount to minor units returns 92,000 instead of 920. The inverse conversion displays 9.2 instead of 920. The seller-net calculation also receives the incorrect minor-unit amount.

This changes `decimalPlaces || 2` to `decimalPlaces ?? 2`, preserving zero precision while retaining the fallback for unknown currencies. Regression tests cover zero-decimal currencies in both directions, uppercase JPY, the unknown-currency fallback, and the seller-net calculation. Existing two- and three-decimal tests remain green.

Validation on the current master base:
- Targeted amount-conversion and seller-net suites: 36 passing.
- TypeScript: `npm run typecheck` passes.
- Full CircleCI pipeline: build, database migrations/seeds, backend tests, and frontend tests passed on commit `3866061` ([run #4987](https://circleci.com/gh/worknenjoy/gitpay/4987)).
- No real payments were exercised; this does not establish that production transactions were affected.

This contribution was prepared with OpenAI Codex assistance and independently reviewed by a second coding agent.

Would you consider a **USD 25 bounty** for accepting and merging this fix? No bounty was previously agreed; this is an optional request. Payment details can be shared privately after agreement.
