### PR TITLE
Fix premature empty state while payment history is loading

### DIFF
--- a/frontend/src/reducers/paymentRequestPaymentReducer.ts
+++ b/frontend/src/reducers/paymentRequestPaymentReducer.ts
@@ -29,7 +29,7 @@ export const paymentRequestPayments = (
     case LIST_PAYMENT_REQUEST_PAYMENT_REQUESTED:
       return {
         ...state,
-        completed: true,
+        completed: false,
         error: null
       }
     case LIST_PAYMENT_REQUEST_PAYMENT_SUCCEEDED:

--- a/frontend/tests/reducers/paymentRequestPaymentReducer.test.ts
+++ b/frontend/tests/reducers/paymentRequestPaymentReducer.test.ts
@@ -1,0 +1,57 @@
+jest.mock('axios', () => ({}), { virtual: true })
+jest.mock('../../src/consts', () => ({ API_URL: 'http://localhost:3000' }))
+jest.mock('../../src/actions/notificationActions', () => ({}))
+
+import {
+  listPaymentRequestPaymentRequested,
+  listPaymentRequestPaymentSucceeded,
+  listPaymentRequestPaymentFailed
+} from '../../src/actions/paymentRequestPaymentActions'
+import { paymentRequestPayments } from '../../src/reducers/paymentRequestPaymentReducer'
+
+describe('payment request payments loading lifecycle', () => {
+  it('keeps the initial request pending until a response arrives', () => {
+    const pending = paymentRequestPayments(undefined, listPaymentRequestPaymentRequested())
+
+    expect(pending.completed).toBe(false)
+    expect(pending.data).toEqual([])
+    expect(pending.error).toBeNull()
+  })
+
+  it('marks a refresh pending while retaining the previously loaded rows', () => {
+    const rows = [{ id: 42, status: 'paid' }]
+    const loaded = paymentRequestPayments(undefined, listPaymentRequestPaymentSucceeded(rows))
+    const pending = paymentRequestPayments(loaded, listPaymentRequestPaymentRequested())
+
+    expect(pending.completed).toBe(false)
+    expect(pending.data).toBe(rows)
+    expect(loaded.completed).toBe(true)
+  })
+
+  it('clears a previous error when retrying and completes with new rows', () => {
+    const failed = paymentRequestPayments(undefined, listPaymentRequestPaymentFailed('offline'))
+    const pending = paymentRequestPayments(failed, listPaymentRequestPaymentRequested())
+    const rows = [{ id: 43 }]
+    const loaded = paymentRequestPayments(pending, listPaymentRequestPaymentSucceeded(rows))
+
+    expect(pending).toMatchObject({ completed: false, error: null })
+    expect(loaded).toEqual({ completed: true, error: null, data: rows })
+  })
+
+  it('only marks an empty result complete after a successful response', () => {
+    const pending = paymentRequestPayments(undefined, listPaymentRequestPaymentRequested())
+    const loaded = paymentRequestPayments(pending, listPaymentRequestPaymentSucceeded([]))
+
+    expect(loaded).toEqual({ completed: true, error: null, data: [] })
+  })
+
+  it('completes a failed refresh without discarding previously loaded rows', () => {
+    const rows = [{ id: 42 }]
+    const loaded = paymentRequestPayments(undefined, listPaymentRequestPaymentSucceeded(rows))
+    const pending = paymentRequestPayments(loaded, listPaymentRequestPaymentRequested())
+    const error = new Error('Network Error')
+    const failed = paymentRequestPayments(pending, listPaymentRequestPaymentFailed(error))
+
+    expect(failed).toEqual({ completed: true, error, data: rows })
+  })
+})

--- a/frontend/tests/reducers/paymentRequestPaymentReducer.test.ts
+++ b/frontend/tests/reducers/paymentRequestPaymentReducer.test.ts
@@ -34,7 +34,8 @@ describe('payment request payments loading lifecycle', () => {
     const rows = [{ id: 43 }]
     const loaded = paymentRequestPayments(pending, listPaymentRequestPaymentSucceeded(rows))
 
-    expect(pending).toMatchObject({ completed: false, error: null })
+    expect(pending.completed).toBe(false)
+    expect(pending.error).toBeNull()
     expect(loaded).toEqual({ completed: true, error: null, data: rows })
   })
 


### PR DESCRIPTION
Payment history currently marks LIST_PAYMENT_REQUEST_PAYMENT_REQUESTED as completed before the API responds. PrimaryDataPage interprets a completed request with an empty array as an empty result, so the first load can display "No payments received yet" prematurely. Refreshes also incorrectly appear complete.

This changes the requested-state flag to completed: false, preserving existing rows and clearing the previous error. Five regression tests exercise the real reducer and action creators: initial load, refresh with existing rows, retry after failure, empty success, and failed refresh.

Validation: all five focused tests pass with Jest 29.7 and ts-jest 29.4.1 using an isolated Node test configuration (TypeScript diagnostics disabled). The original validation reported three failures before the fix and five passing tests afterward; the five passing tests were rerun for this submission. git diff --cached --check passes. The full frontend suite, browser tests, and full project lint/typecheck have not been run.

Submitted following Alexandre's invitation by email. Happy to contribute this fix with no bounty attached.